### PR TITLE
AB#57 - Utilize NYC Core Bootstrap 4 CSS / JS

### DIFF
--- a/public/Gemfile
+++ b/public/Gemfile
@@ -17,19 +17,17 @@ gem 'sprockets-rails', '2.3.3'
 gem 'atomic', '= 1.0.1'
 gem 'mizuno', '0.6.11'
 
-# use bootstrap's sass
-gem 'bootstrap-sass', '>= 3.4.1'
+gem 'bootstrap', '~> 4.5.2'
+
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0', '>= 5.0.6'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '3.0.4'
 # Use font-awesome icons
-gem 'font-awesome-sass', '4.7.0'
+gem 'font-awesome-sass', '~> 5.13.0'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '4.2.2'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'therubyrhino'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 

--- a/public/Gemfile.lock
+++ b/public/Gemfile.lock
@@ -56,9 +56,10 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    bootstrap-sass (3.4.1)
-      autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
+    bootstrap (4.5.2)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 1.14.3, < 2)
+      sassc-rails (>= 2.0.0)
     builder (3.2.4)
     capybara (3.15.1)
       addressable
@@ -112,8 +113,8 @@ GEM
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
-    font-awesome-sass (4.7.0)
-      sass (>= 3.2)
+    font-awesome-sass (5.13.0)
+      sassc (>= 1.11)
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -158,6 +159,7 @@ GEM
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
+    popper_js (1.16.0)
     pry (0.11.3-java)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -249,6 +251,12 @@ GEM
       tilt (>= 1.1, < 3)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -265,9 +273,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    therubyrhino (2.1.2)
-      therubyrhino_jar (>= 1.7.4, < 1.7.9)
-    therubyrhino_jar (1.7.8)
     thor (1.0.1)
     thread_safe (0.3.6-java)
     tilt (2.0.10)
@@ -298,7 +303,7 @@ PLATFORMS
 DEPENDENCIES
   atomic (= 1.0.1)
   axe-matchers (~> 2.6)
-  bootstrap-sass (>= 3.4.1)
+  bootstrap
   capybara (= 3.15.1)
   clipboard-rails
   coffee-rails (= 4.2.2)
@@ -306,7 +311,7 @@ DEPENDENCIES
   excon (>= 0.71.0)
   factory_bot_rails (~> 4.11, >= 4.11.1)
   fog-aws (= 2.0.0)
-  font-awesome-sass (= 4.7.0)
+  font-awesome-sass (~> 5.13.0)
   htmlentities (~> 4.3, >= 4.3.4)
   i18n (= 0.9.1)
   jquery-rails
@@ -333,7 +338,6 @@ DEPENDENCIES
   selenium-webdriver (~> 3.142, >= 3.142.3)
   simplecov (= 0.7.1)
   sprockets-rails (= 2.3.3)
-  therubyrhino
   turbolinks (~> 5)
   tzinfo-data
   uglifier (= 3.0.4)

--- a/public/app/assets/javascripts/application.js
+++ b/public/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
-//= require jquery
+//= require jquery3
+//= require popper
 //= require jquery_ujs
 //= require bootstrap-sprockets
 //= require jquery.scrollTo/jquery.scrollTo

--- a/public/app/assets/stylesheets/application.scss
+++ b/public/app/assets/stylesheets/application.scss
@@ -13,22 +13,10 @@
  * NO = require_tree .
  * NO = require_self
  */
-// "bootstrap-sprockets" must be imported before "bootstrap" and "bootstrap/variables"
-@import "bootstrap-sprockets";
 @import "bootstrap";
+@import "custom";
+@import "theme";
 
-@import  "archivesspace/fonts";
-@import "archivesspace/colors";
-@import "archivesspace/variables";
 //font-awesome
 @import "font-awesome-sprockets";
 @import "font-awesome";
-// @import "bootstrap-sass/_glyphicons.scss";
-// @import "load-awesome/line-spin-clockwise-fade.css";
-@import "foundation/_functions.scss";
-@import "archivesspace/aspace"; 
-@import "archivesspace/record-type-badge";
-
-@import "archivesspace/infinite-scroll";
-@import "archivesspace/largetree";
-@import "archivesspace/mixed-content";

--- a/public/app/assets/stylesheets/custom.scss
+++ b/public/app/assets/stylesheets/custom.scss
@@ -1,0 +1,67 @@
+
+h1 {
+    line-height: .5;
+}
+h1 a {
+    color: #000;
+}
+h1 a:hover {
+    text-decoration: none;
+    color: #000;
+}
+
+.nav-pills .nav-link.active, .nav-pills .nav-link.active:hover {
+    text-decoration: none !important;
+    background-color: #684499 !important;
+    color: white !important;
+}
+table a {
+    color: #181A7B;
+}
+
+ol.breadcrumb {
+    padding-left: 2px;
+}
+ol.breadcrumb li {
+    display: inline;
+}
+.names span {
+    margin-right: 5px;
+    padding-left: 2px;
+}
+#azindex {
+    float: left;
+    margin: 5px 0 5px 5px;
+    padding: 0px 5px 25px 5px;
+}
+
+#index li {
+    float: left;
+    height: 2em;
+    list-style-type: none;
+    padding: 0;
+    width: 2em;
+}
+
+#index a:link, #index a:visited {
+    display: block;
+    height: 2em;
+    padding: 0.75em 0 0 0;
+    text-align: center;
+    width: 3em;
+}
+.input-group #startyear, #endyear {
+    width: 120px !important;
+    flex: none;
+    display: inline-block;
+}
+ul {
+    margin-left: -15px;
+}
+ul a {
+    color: #181A7B;
+}
+
+.subgroups-list {
+    list-style: none;
+}

--- a/public/app/assets/stylesheets/theme.scss
+++ b/public/app/assets/stylesheets/theme.scss
@@ -1,0 +1,11293 @@
+@charset "UTF-8";
+/*
+
+In this file:
+
+// A. SCSS imports (required)
+// B. Theme styles
+
+*/
+/*!
+*
+*    /NNNNNNh\     oNNNNNN\ /NNNNNN\      /NNNNNN\  /mNNNNNNNNNNNNNNNy-\  ®
+*   .MMMMMMMMMh:`  NMMMMMMMMMMMMMMMM.    -MMMMMMMM+oNMMMMMMMMMMMMMMMMMMy-
+*   .MMMMMMMMMMMd/`NMMMMMMMMMMMMMMMMh:``/dMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM`
+*   .MMMMMMMMMMMMMdMMMMMMMMMMMMMMMMMMMddMMMMMMMMMMMMMMMMMMMNNNNNMMMMMMMMM|
+*   .MMMMMMMMMMMMMMMMMMMMMMNMMMMMMMMMMMMMMMMMMMMMNNMMMMMMMN-----oddddddd/
+*   .MMMMMMMMMMMMMMMMMMMMMMy:hMMMMMMMMMMMMMMMMMNy:hMMMMMMMm      ``````
+*   .MMMMMMMMMMMMMMMMMMMMMMs  :hMMMMMMMMMMMMMNy-  hMMMMMMMN-----oddddddd\
+*   .MMMMMMMMdNMMMMMMMMMMMMs    -yNMMMMMMMMNs-    hMMMMMMMMNNNNNMMMMMMMMM`
+*   .MMMMMMMM+.sNMMMMMMMMMMs      +MMMMMMMM/      yMMMMMMMMMMMMMMMMMMMMMM`
+*   .MMMMMMMM+  .sNMMMMMMMMs      /MMMMMMMM-      `omMMMMMMMMMMMMMMMMMMy-
+*   `sNNNNNN/     `omNNNNNd/      .yNNNNNN/         `+mNNNNNNNNNNNNNNy/
+*
+*
+* * Bootstrap v4.3.1 (https://getbootstrap.com/)
+* * Copyright 2011-2019 The Bootstrap Authors
+* * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+*
+* * ///////////////////////////////////////////////////////////////////////
+* *
+* * NYC CORE FRAMEWORK   ....   v0.1
+* * Created by NYC Gov Lab & Studio at NYC Information Technology & Telecommunications (DoITT)
+* *
+* * ///////////////////////////////////////////////////////////////////////
+*
+*/
+/*
+
+In this file:
+
+// A. Bootstrap colors
+// B. Theme colors
+// C. Sitewide grays
+// D. Breakpoints
+// E. Spacing utilities
+// F. Grid gutter and container widths
+// G. Additional widths
+// H. Font Settings
+// I. Border and border radius
+// J. Buttons and links
+// K. Cards
+// L. Components, navs, and dropdowns
+// M. Box shadows
+// N. Forms and alerts
+// O. Modals
+// P. Figures
+
+*/
+/*
+
+In this file:
+
+// A. Required Bootstrap imports
+// B. Remove unneeded sass map values
+// c. Optional Bootstrap imports
+
+*/
+:root {
+    --blue: #0029F7;
+    --indigo: #8f51f4;
+    --purple: #8762cd;
+    --pink: #e8006d;
+    --red: #ea172b;
+    --orange: #c45500;
+    --yellow: #ffc107;
+    --green: #21883f;
+    --teal: #0c8763;
+    --cyan: #008299;
+    --white: #fff;
+    --gray: #777677;
+    --gray-dark: #343a40;
+    --primary: #181A7B;
+    --secondary: #3B6CF6;
+    --success: #21883f;
+    --info: #A513B6;
+    --warning: #ffc107;
+    --danger: #ea172b;
+    --light: #e6ecf7;
+    --dark: #0A1438;
+    --white: #fff;
+    --black: #000;
+    --breakpoint-xs: 0;
+    --breakpoint-sm: 480px;
+    --breakpoint-md: 720px;
+    --breakpoint-lg: 960px;
+    --breakpoint-xl: 1200px;
+    --breakpoint-xxl: 1440px;
+    --font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    font-family: sans-serif;
+    line-height: 1.15;
+    -webkit-text-size-adjust: 100%;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
+    display: block;
+}
+
+body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #212529;
+    text-align: left;
+    background-color: #fff;
+}
+
+[tabindex="-1"]:focus {
+    outline: 0 !important;
+}
+
+hr {
+    box-sizing: content-box;
+    height: 0;
+    overflow: visible;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+}
+
+p {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+abbr[title],
+abbr[data-original-title] {
+    text-decoration: underline;
+    text-decoration: underline dotted;
+    cursor: help;
+    border-bottom: 0;
+    text-decoration-skip-ink: none;
+}
+
+address {
+    margin-bottom: 1rem;
+    font-style: normal;
+    line-height: inherit;
+}
+
+ol,
+ul,
+dl {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+ol ol,
+ul ul,
+ol ul,
+ul ol {
+    margin-bottom: 0;
+}
+
+dt {
+    font-weight: 700;
+}
+
+dd {
+    margin-bottom: .5rem;
+    margin-left: 0;
+}
+
+blockquote {
+    margin: 0 0 1rem;
+}
+
+b,
+strong {
+    font-weight: bolder;
+}
+
+small {
+    font-size: 80%;
+}
+
+sub,
+sup {
+    position: relative;
+    font-size: 75%;
+    line-height: 0;
+    vertical-align: baseline;
+}
+
+sub {
+    bottom: -.25em;
+}
+
+sup {
+    top: -.5em;
+}
+
+a {
+    color: #0029F7;
+    text-decoration: none;
+    background-color: transparent;
+}
+
+a:hover {
+    color: #001cab;
+    text-decoration: none;
+}
+
+a:not([href]):not([tabindex]) {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:not([href]):not([tabindex]):hover, a:not([href]):not([tabindex]):focus {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:not([href]):not([tabindex]):focus {
+    outline: 0;
+}
+
+pre,
+code,
+kbd,
+samp {
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 1em;
+}
+
+pre {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    overflow: auto;
+}
+
+figure {
+    margin: 0 0 1rem;
+}
+
+img {
+    vertical-align: middle;
+    border-style: none;
+}
+
+svg {
+    overflow: hidden;
+    vertical-align: middle;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+caption {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    color: #495057;
+    text-align: left;
+    caption-side: bottom;
+}
+
+th {
+    text-align: inherit;
+}
+
+label {
+    display: inline-block;
+    margin-bottom: 0.5rem;
+}
+
+button {
+    border-radius: 0;
+}
+
+button:focus {
+    outline: 1px dotted;
+    outline: 5px auto -webkit-focus-ring-color;
+}
+
+input,
+button,
+select,
+optgroup,
+textarea {
+    margin: 0;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+}
+
+button,
+input {
+    overflow: visible;
+}
+
+button,
+select {
+    text-transform: none;
+}
+
+select {
+    word-wrap: normal;
+}
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+    -webkit-appearance: button;
+}
+
+button:not(:disabled),
+[type="button"]:not(:disabled),
+[type="reset"]:not(:disabled),
+[type="submit"]:not(:disabled) {
+    cursor: pointer;
+}
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+    padding: 0;
+    border-style: none;
+}
+
+input[type="radio"],
+input[type="checkbox"] {
+    box-sizing: border-box;
+    padding: 0;
+}
+
+input[type="date"],
+input[type="time"],
+input[type="datetime-local"],
+input[type="month"] {
+    -webkit-appearance: listbox;
+}
+
+textarea {
+    overflow: auto;
+    resize: vertical;
+}
+
+fieldset {
+    min-width: 0;
+    padding: 0;
+    margin: 0;
+    border: 0;
+}
+
+legend {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    padding: 0;
+    margin-bottom: .5rem;
+    font-size: 1.5rem;
+    line-height: inherit;
+    color: inherit;
+    white-space: normal;
+}
+
+@media (max-width: 1200px) {
+    legend {
+        font-size: calc(1.275rem + 0.3vw) ;
+    }
+}
+
+progress {
+    vertical-align: baseline;
+}
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+    height: auto;
+}
+
+[type="search"] {
+    outline-offset: -2px;
+    -webkit-appearance: none;
+}
+
+[type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+}
+
+::-webkit-file-upload-button {
+    font: inherit;
+    -webkit-appearance: button;
+}
+
+output {
+    display: inline-block;
+}
+
+summary {
+    display: list-item;
+    cursor: pointer;
+}
+
+template {
+    display: none;
+}
+
+[hidden] {
+    display: none !important;
+}
+
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6 {
+    margin-bottom: 0.5rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+h1, .h1 {
+    font-size: 2.5rem;
+}
+
+@media (max-width: 1200px) {
+    h1, .h1 {
+        font-size: calc(1.375rem + 1.5vw) ;
+    }
+}
+
+h2, .h2 {
+    font-size: 2rem;
+}
+
+@media (max-width: 1200px) {
+    h2, .h2 {
+        font-size: calc(1.325rem + 0.9vw) ;
+    }
+}
+
+h3, .h3 {
+    font-size: 1.75rem;
+}
+
+@media (max-width: 1200px) {
+    h3, .h3 {
+        font-size: calc(1.3rem + 0.6vw) ;
+    }
+}
+
+h4, .h4 {
+    font-size: 1.5rem;
+}
+
+@media (max-width: 1200px) {
+    h4, .h4 {
+        font-size: calc(1.275rem + 0.3vw) ;
+    }
+}
+
+h5, .h5 {
+    font-size: 1.25rem;
+}
+
+h6, .h6 {
+    font-size: 1rem;
+}
+
+.lead {
+    font-size: 1.25rem;
+    font-weight: 400;
+}
+
+.display-1 {
+    font-size: 6rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+@media (max-width: 1200px) {
+    .display-1 {
+        font-size: calc(1.725rem + 5.7vw) ;
+    }
+}
+
+.display-2 {
+    font-size: 5.5rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+@media (max-width: 1200px) {
+    .display-2 {
+        font-size: calc(1.675rem + 5.1vw) ;
+    }
+}
+
+.display-3 {
+    font-size: 4.5rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+@media (max-width: 1200px) {
+    .display-3 {
+        font-size: calc(1.575rem + 3.9vw) ;
+    }
+}
+
+.display-4 {
+    font-size: 3.5rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+@media (max-width: 1200px) {
+    .display-4 {
+        font-size: calc(1.475rem + 2.7vw) ;
+    }
+}
+
+hr {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    border: 0;
+    border-top: 1px solid #dee2e6;
+}
+
+small,
+.small {
+    font-size: 0.875rem;
+    font-weight: 400;
+}
+
+mark,
+.mark {
+    padding: 0.2em;
+    background-color: #fcf8e3;
+}
+
+.list-unstyled {
+    padding-left: 0;
+    list-style: none;
+}
+
+.list-inline {
+    padding-left: 0;
+    list-style: none;
+}
+
+.list-inline-item {
+    display: inline-block;
+}
+
+.list-inline-item:not(:last-child) {
+    margin-right: 0.5rem;
+}
+
+.initialism {
+    font-size: 90%;
+    text-transform: uppercase;
+}
+
+.blockquote {
+    margin-bottom: 1rem;
+    font-size: 1.25rem;
+}
+
+.blockquote-footer {
+    display: block;
+    font-size: 0.875rem;
+    color: #495057;
+}
+
+.blockquote-footer::before {
+    content: "\2014\00A0";
+}
+
+.img-fluid, img {
+    max-width: 100%;
+    height: auto;
+}
+
+.img-thumbnail {
+    padding: 0.25rem;
+    background-color: #fff;
+    border: 1px solid #dee2e6;
+    max-width: 100%;
+    height: auto;
+}
+
+.figure {
+    display: inline-block;
+}
+
+.figure-img {
+    margin-bottom: 0.5rem;
+    line-height: 1;
+}
+
+.figure-caption {
+    font-size: 1rem;
+    color: #212529;
+}
+
+code {
+    font-size: 87.5%;
+    color: #e8006d;
+    word-break: break-word;
+}
+
+a > code {
+    color: inherit;
+}
+
+kbd {
+    padding: 0.2rem 0.4rem;
+    font-size: 87.5%;
+    color: #fff;
+    background-color: #212529;
+}
+
+kbd kbd {
+    padding: 0;
+    font-size: 100%;
+    font-weight: 700;
+}
+
+pre {
+    display: block;
+    font-size: 87.5%;
+    color: #212529;
+}
+
+pre code {
+    font-size: inherit;
+    color: inherit;
+    word-break: normal;
+}
+
+.pre-scrollable {
+    max-height: 340px;
+    overflow-y: scroll;
+}
+
+.container {
+    width: 100%;
+    padding-right: 1rem;
+    padding-left: 1rem;
+    margin-right: auto;
+    margin-left: auto;
+}
+
+@media (min-width: 480px) {
+    .container {
+        max-width: 448px;
+    }
+}
+
+@media (min-width: 720px) {
+    .container {
+        max-width: 688px;
+    }
+}
+
+@media (min-width: 960px) {
+    .container {
+        max-width: 928px;
+    }
+}
+
+@media (min-width: 1200px) {
+    .container {
+        max-width: 1168px;
+    }
+}
+
+.container-fluid {
+    width: 100%;
+    padding-right: 1rem;
+    padding-left: 1rem;
+    margin-right: auto;
+    margin-left: auto;
+}
+
+.row, [id="languages"] ul {
+    display: flex;
+    flex-wrap: wrap;
+    margin-right: -1rem;
+    margin-left: -1rem;
+}
+
+.no-gutters {
+    margin-right: 0;
+    margin-left: 0;
+}
+
+.no-gutters > .col,
+.no-gutters > [class*="col-"] {
+    padding-right: 0;
+    padding-left: 0;
+}
+
+.col-1, .col-2, .col-3, .col-4, .col-5, .col-6, [id="languages"] ul li, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col,
+.col-auto, .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12, .col-sm,
+.col-sm-auto, .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12, .col-md,
+.col-md-auto, .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12, .col-lg,
+.col-lg-auto, .col-xl-1, .col-xl-2, .col-xl-3, .col-xl-4, .col-xl-5, .col-xl-6, .col-xl-7, .col-xl-8, .col-xl-9, .col-xl-10, .col-xl-11, .col-xl-12, .col-xl,
+.col-xl-auto, .col-xxl-1, .col-xxl-2, .col-xxl-3, .col-xxl-4, .col-xxl-5, .col-xxl-6, .col-xxl-7, .col-xxl-8, .col-xxl-9, .col-xxl-10, .col-xxl-11, .col-xxl-12, .col-xxl,
+.col-xxl-auto {
+    position: relative;
+    width: 100%;
+    padding-right: 1rem;
+    padding-left: 1rem;
+}
+
+.col {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+}
+
+.col-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%;
+}
+
+.col-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%;
+}
+
+.col-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%;
+}
+
+.col-3 {
+    flex: 0 0 25%;
+    max-width: 25%;
+}
+
+.col-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%;
+}
+
+.col-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%;
+}
+
+.col-6, [id="languages"] ul li {
+    flex: 0 0 50%;
+    max-width: 50%;
+}
+
+.col-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%;
+}
+
+.col-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%;
+}
+
+.col-9 {
+    flex: 0 0 75%;
+    max-width: 75%;
+}
+
+.col-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%;
+}
+
+.col-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%;
+}
+
+.col-12 {
+    flex: 0 0 100%;
+    max-width: 100%;
+}
+
+.order-first {
+    order: -1;
+}
+
+.order-last {
+    order: 13;
+}
+
+.order-0 {
+    order: 0;
+}
+
+.order-1 {
+    order: 1;
+}
+
+.order-2 {
+    order: 2;
+}
+
+.order-3 {
+    order: 3;
+}
+
+.order-4 {
+    order: 4;
+}
+
+.order-5 {
+    order: 5;
+}
+
+.order-6 {
+    order: 6;
+}
+
+.order-7 {
+    order: 7;
+}
+
+.order-8 {
+    order: 8;
+}
+
+.order-9 {
+    order: 9;
+}
+
+.order-10 {
+    order: 10;
+}
+
+.order-11 {
+    order: 11;
+}
+
+.order-12 {
+    order: 12;
+}
+
+.offset-1 {
+    margin-left: 8.3333333333%;
+}
+
+.offset-2 {
+    margin-left: 16.6666666667%;
+}
+
+.offset-3 {
+    margin-left: 25%;
+}
+
+.offset-4 {
+    margin-left: 33.3333333333%;
+}
+
+.offset-5 {
+    margin-left: 41.6666666667%;
+}
+
+.offset-6 {
+    margin-left: 50%;
+}
+
+.offset-7 {
+    margin-left: 58.3333333333%;
+}
+
+.offset-8 {
+    margin-left: 66.6666666667%;
+}
+
+.offset-9 {
+    margin-left: 75%;
+}
+
+.offset-10 {
+    margin-left: 83.3333333333%;
+}
+
+.offset-11 {
+    margin-left: 91.6666666667%;
+}
+
+@media (min-width: 480px) {
+    .col-sm {
+        flex-basis: 0;
+        flex-grow: 1;
+        max-width: 100%;
+    }
+    .col-sm-auto {
+        flex: 0 0 auto;
+        width: auto;
+        max-width: 100%;
+    }
+    .col-sm-1 {
+        flex: 0 0 8.3333333333%;
+        max-width: 8.3333333333%;
+    }
+    .col-sm-2 {
+        flex: 0 0 16.6666666667%;
+        max-width: 16.6666666667%;
+    }
+    .col-sm-3 {
+        flex: 0 0 25%;
+        max-width: 25%;
+    }
+    .col-sm-4 {
+        flex: 0 0 33.3333333333%;
+        max-width: 33.3333333333%;
+    }
+    .col-sm-5 {
+        flex: 0 0 41.6666666667%;
+        max-width: 41.6666666667%;
+    }
+    .col-sm-6 {
+        flex: 0 0 50%;
+        max-width: 50%;
+    }
+    .col-sm-7 {
+        flex: 0 0 58.3333333333%;
+        max-width: 58.3333333333%;
+    }
+    .col-sm-8 {
+        flex: 0 0 66.6666666667%;
+        max-width: 66.6666666667%;
+    }
+    .col-sm-9 {
+        flex: 0 0 75%;
+        max-width: 75%;
+    }
+    .col-sm-10 {
+        flex: 0 0 83.3333333333%;
+        max-width: 83.3333333333%;
+    }
+    .col-sm-11 {
+        flex: 0 0 91.6666666667%;
+        max-width: 91.6666666667%;
+    }
+    .col-sm-12 {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+    .order-sm-first {
+        order: -1;
+    }
+    .order-sm-last {
+        order: 13;
+    }
+    .order-sm-0 {
+        order: 0;
+    }
+    .order-sm-1 {
+        order: 1;
+    }
+    .order-sm-2 {
+        order: 2;
+    }
+    .order-sm-3 {
+        order: 3;
+    }
+    .order-sm-4 {
+        order: 4;
+    }
+    .order-sm-5 {
+        order: 5;
+    }
+    .order-sm-6 {
+        order: 6;
+    }
+    .order-sm-7 {
+        order: 7;
+    }
+    .order-sm-8 {
+        order: 8;
+    }
+    .order-sm-9 {
+        order: 9;
+    }
+    .order-sm-10 {
+        order: 10;
+    }
+    .order-sm-11 {
+        order: 11;
+    }
+    .order-sm-12 {
+        order: 12;
+    }
+    .offset-sm-0 {
+        margin-left: 0;
+    }
+    .offset-sm-1 {
+        margin-left: 8.3333333333%;
+    }
+    .offset-sm-2 {
+        margin-left: 16.6666666667%;
+    }
+    .offset-sm-3 {
+        margin-left: 25%;
+    }
+    .offset-sm-4 {
+        margin-left: 33.3333333333%;
+    }
+    .offset-sm-5 {
+        margin-left: 41.6666666667%;
+    }
+    .offset-sm-6 {
+        margin-left: 50%;
+    }
+    .offset-sm-7 {
+        margin-left: 58.3333333333%;
+    }
+    .offset-sm-8 {
+        margin-left: 66.6666666667%;
+    }
+    .offset-sm-9 {
+        margin-left: 75%;
+    }
+    .offset-sm-10 {
+        margin-left: 83.3333333333%;
+    }
+    .offset-sm-11 {
+        margin-left: 91.6666666667%;
+    }
+}
+
+@media (min-width: 720px) {
+    .col-md {
+        flex-basis: 0;
+        flex-grow: 1;
+        max-width: 100%;
+    }
+    .col-md-auto {
+        flex: 0 0 auto;
+        width: auto;
+        max-width: 100%;
+    }
+    .col-md-1 {
+        flex: 0 0 8.3333333333%;
+        max-width: 8.3333333333%;
+    }
+    .col-md-2 {
+        flex: 0 0 16.6666666667%;
+        max-width: 16.6666666667%;
+    }
+    .col-md-3 {
+        flex: 0 0 25%;
+        max-width: 25%;
+    }
+    .col-md-4, [id="languages"] ul li {
+        flex: 0 0 33.3333333333%;
+        max-width: 33.3333333333%;
+    }
+    .col-md-5 {
+        flex: 0 0 41.6666666667%;
+        max-width: 41.6666666667%;
+    }
+    .col-md-6 {
+        flex: 0 0 50%;
+        max-width: 50%;
+    }
+    .col-md-7 {
+        flex: 0 0 58.3333333333%;
+        max-width: 58.3333333333%;
+    }
+    .col-md-8 {
+        flex: 0 0 66.6666666667%;
+        max-width: 66.6666666667%;
+    }
+    .col-md-9 {
+        flex: 0 0 75%;
+        max-width: 75%;
+    }
+    .col-md-10 {
+        flex: 0 0 83.3333333333%;
+        max-width: 83.3333333333%;
+    }
+    .col-md-11 {
+        flex: 0 0 91.6666666667%;
+        max-width: 91.6666666667%;
+    }
+    .col-md-12 {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+    .order-md-first {
+        order: -1;
+    }
+    .order-md-last {
+        order: 13;
+    }
+    .order-md-0 {
+        order: 0;
+    }
+    .order-md-1 {
+        order: 1;
+    }
+    .order-md-2 {
+        order: 2;
+    }
+    .order-md-3 {
+        order: 3;
+    }
+    .order-md-4 {
+        order: 4;
+    }
+    .order-md-5 {
+        order: 5;
+    }
+    .order-md-6 {
+        order: 6;
+    }
+    .order-md-7 {
+        order: 7;
+    }
+    .order-md-8 {
+        order: 8;
+    }
+    .order-md-9 {
+        order: 9;
+    }
+    .order-md-10 {
+        order: 10;
+    }
+    .order-md-11 {
+        order: 11;
+    }
+    .order-md-12 {
+        order: 12;
+    }
+    .offset-md-0 {
+        margin-left: 0;
+    }
+    .offset-md-1 {
+        margin-left: 8.3333333333%;
+    }
+    .offset-md-2 {
+        margin-left: 16.6666666667%;
+    }
+    .offset-md-3 {
+        margin-left: 25%;
+    }
+    .offset-md-4 {
+        margin-left: 33.3333333333%;
+    }
+    .offset-md-5 {
+        margin-left: 41.6666666667%;
+    }
+    .offset-md-6 {
+        margin-left: 50%;
+    }
+    .offset-md-7 {
+        margin-left: 58.3333333333%;
+    }
+    .offset-md-8 {
+        margin-left: 66.6666666667%;
+    }
+    .offset-md-9 {
+        margin-left: 75%;
+    }
+    .offset-md-10 {
+        margin-left: 83.3333333333%;
+    }
+    .offset-md-11 {
+        margin-left: 91.6666666667%;
+    }
+}
+
+@media (min-width: 960px) {
+    .col-lg {
+        flex-basis: 0;
+        flex-grow: 1;
+        max-width: 100%;
+    }
+    .col-lg-auto {
+        flex: 0 0 auto;
+        width: auto;
+        max-width: 100%;
+    }
+    .col-lg-1 {
+        flex: 0 0 8.3333333333%;
+        max-width: 8.3333333333%;
+    }
+    .col-lg-2 {
+        flex: 0 0 16.6666666667%;
+        max-width: 16.6666666667%;
+    }
+    .col-lg-3 {
+        flex: 0 0 25%;
+        max-width: 25%;
+    }
+    .col-lg-4 {
+        flex: 0 0 33.3333333333%;
+        max-width: 33.3333333333%;
+    }
+    .col-lg-5 {
+        flex: 0 0 41.6666666667%;
+        max-width: 41.6666666667%;
+    }
+    .col-lg-6 {
+        flex: 0 0 50%;
+        max-width: 50%;
+    }
+    .col-lg-7 {
+        flex: 0 0 58.3333333333%;
+        max-width: 58.3333333333%;
+    }
+    .col-lg-8 {
+        flex: 0 0 66.6666666667%;
+        max-width: 66.6666666667%;
+    }
+    .col-lg-9 {
+        flex: 0 0 75%;
+        max-width: 75%;
+    }
+    .col-lg-10 {
+        flex: 0 0 83.3333333333%;
+        max-width: 83.3333333333%;
+    }
+    .col-lg-11 {
+        flex: 0 0 91.6666666667%;
+        max-width: 91.6666666667%;
+    }
+    .col-lg-12 {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+    .order-lg-first {
+        order: -1;
+    }
+    .order-lg-last {
+        order: 13;
+    }
+    .order-lg-0 {
+        order: 0;
+    }
+    .order-lg-1 {
+        order: 1;
+    }
+    .order-lg-2 {
+        order: 2;
+    }
+    .order-lg-3 {
+        order: 3;
+    }
+    .order-lg-4 {
+        order: 4;
+    }
+    .order-lg-5 {
+        order: 5;
+    }
+    .order-lg-6 {
+        order: 6;
+    }
+    .order-lg-7 {
+        order: 7;
+    }
+    .order-lg-8 {
+        order: 8;
+    }
+    .order-lg-9 {
+        order: 9;
+    }
+    .order-lg-10 {
+        order: 10;
+    }
+    .order-lg-11 {
+        order: 11;
+    }
+    .order-lg-12 {
+        order: 12;
+    }
+    .offset-lg-0 {
+        margin-left: 0;
+    }
+    .offset-lg-1 {
+        margin-left: 8.3333333333%;
+    }
+    .offset-lg-2 {
+        margin-left: 16.6666666667%;
+    }
+    .offset-lg-3 {
+        margin-left: 25%;
+    }
+    .offset-lg-4 {
+        margin-left: 33.3333333333%;
+    }
+    .offset-lg-5 {
+        margin-left: 41.6666666667%;
+    }
+    .offset-lg-6 {
+        margin-left: 50%;
+    }
+    .offset-lg-7 {
+        margin-left: 58.3333333333%;
+    }
+    .offset-lg-8 {
+        margin-left: 66.6666666667%;
+    }
+    .offset-lg-9 {
+        margin-left: 75%;
+    }
+    .offset-lg-10 {
+        margin-left: 83.3333333333%;
+    }
+    .offset-lg-11 {
+        margin-left: 91.6666666667%;
+    }
+}
+
+@media (min-width: 1200px) {
+    .col-xl {
+        flex-basis: 0;
+        flex-grow: 1;
+        max-width: 100%;
+    }
+    .col-xl-auto {
+        flex: 0 0 auto;
+        width: auto;
+        max-width: 100%;
+    }
+    .col-xl-1 {
+        flex: 0 0 8.3333333333%;
+        max-width: 8.3333333333%;
+    }
+    .col-xl-2 {
+        flex: 0 0 16.6666666667%;
+        max-width: 16.6666666667%;
+    }
+    .col-xl-3 {
+        flex: 0 0 25%;
+        max-width: 25%;
+    }
+    .col-xl-4 {
+        flex: 0 0 33.3333333333%;
+        max-width: 33.3333333333%;
+    }
+    .col-xl-5 {
+        flex: 0 0 41.6666666667%;
+        max-width: 41.6666666667%;
+    }
+    .col-xl-6 {
+        flex: 0 0 50%;
+        max-width: 50%;
+    }
+    .col-xl-7 {
+        flex: 0 0 58.3333333333%;
+        max-width: 58.3333333333%;
+    }
+    .col-xl-8 {
+        flex: 0 0 66.6666666667%;
+        max-width: 66.6666666667%;
+    }
+    .col-xl-9 {
+        flex: 0 0 75%;
+        max-width: 75%;
+    }
+    .col-xl-10 {
+        flex: 0 0 83.3333333333%;
+        max-width: 83.3333333333%;
+    }
+    .col-xl-11 {
+        flex: 0 0 91.6666666667%;
+        max-width: 91.6666666667%;
+    }
+    .col-xl-12 {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+    .order-xl-first {
+        order: -1;
+    }
+    .order-xl-last {
+        order: 13;
+    }
+    .order-xl-0 {
+        order: 0;
+    }
+    .order-xl-1 {
+        order: 1;
+    }
+    .order-xl-2 {
+        order: 2;
+    }
+    .order-xl-3 {
+        order: 3;
+    }
+    .order-xl-4 {
+        order: 4;
+    }
+    .order-xl-5 {
+        order: 5;
+    }
+    .order-xl-6 {
+        order: 6;
+    }
+    .order-xl-7 {
+        order: 7;
+    }
+    .order-xl-8 {
+        order: 8;
+    }
+    .order-xl-9 {
+        order: 9;
+    }
+    .order-xl-10 {
+        order: 10;
+    }
+    .order-xl-11 {
+        order: 11;
+    }
+    .order-xl-12 {
+        order: 12;
+    }
+    .offset-xl-0 {
+        margin-left: 0;
+    }
+    .offset-xl-1 {
+        margin-left: 8.3333333333%;
+    }
+    .offset-xl-2 {
+        margin-left: 16.6666666667%;
+    }
+    .offset-xl-3 {
+        margin-left: 25%;
+    }
+    .offset-xl-4 {
+        margin-left: 33.3333333333%;
+    }
+    .offset-xl-5 {
+        margin-left: 41.6666666667%;
+    }
+    .offset-xl-6 {
+        margin-left: 50%;
+    }
+    .offset-xl-7 {
+        margin-left: 58.3333333333%;
+    }
+    .offset-xl-8 {
+        margin-left: 66.6666666667%;
+    }
+    .offset-xl-9 {
+        margin-left: 75%;
+    }
+    .offset-xl-10 {
+        margin-left: 83.3333333333%;
+    }
+    .offset-xl-11 {
+        margin-left: 91.6666666667%;
+    }
+}
+
+@media (min-width: 1440px) {
+    .col-xxl {
+        flex-basis: 0;
+        flex-grow: 1;
+        max-width: 100%;
+    }
+    .col-xxl-auto {
+        flex: 0 0 auto;
+        width: auto;
+        max-width: 100%;
+    }
+    .col-xxl-1 {
+        flex: 0 0 8.3333333333%;
+        max-width: 8.3333333333%;
+    }
+    .col-xxl-2 {
+        flex: 0 0 16.6666666667%;
+        max-width: 16.6666666667%;
+    }
+    .col-xxl-3 {
+        flex: 0 0 25%;
+        max-width: 25%;
+    }
+    .col-xxl-4 {
+        flex: 0 0 33.3333333333%;
+        max-width: 33.3333333333%;
+    }
+    .col-xxl-5 {
+        flex: 0 0 41.6666666667%;
+        max-width: 41.6666666667%;
+    }
+    .col-xxl-6 {
+        flex: 0 0 50%;
+        max-width: 50%;
+    }
+    .col-xxl-7 {
+        flex: 0 0 58.3333333333%;
+        max-width: 58.3333333333%;
+    }
+    .col-xxl-8 {
+        flex: 0 0 66.6666666667%;
+        max-width: 66.6666666667%;
+    }
+    .col-xxl-9 {
+        flex: 0 0 75%;
+        max-width: 75%;
+    }
+    .col-xxl-10 {
+        flex: 0 0 83.3333333333%;
+        max-width: 83.3333333333%;
+    }
+    .col-xxl-11 {
+        flex: 0 0 91.6666666667%;
+        max-width: 91.6666666667%;
+    }
+    .col-xxl-12 {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+    .order-xxl-first {
+        order: -1;
+    }
+    .order-xxl-last {
+        order: 13;
+    }
+    .order-xxl-0 {
+        order: 0;
+    }
+    .order-xxl-1 {
+        order: 1;
+    }
+    .order-xxl-2 {
+        order: 2;
+    }
+    .order-xxl-3 {
+        order: 3;
+    }
+    .order-xxl-4 {
+        order: 4;
+    }
+    .order-xxl-5 {
+        order: 5;
+    }
+    .order-xxl-6 {
+        order: 6;
+    }
+    .order-xxl-7 {
+        order: 7;
+    }
+    .order-xxl-8 {
+        order: 8;
+    }
+    .order-xxl-9 {
+        order: 9;
+    }
+    .order-xxl-10 {
+        order: 10;
+    }
+    .order-xxl-11 {
+        order: 11;
+    }
+    .order-xxl-12 {
+        order: 12;
+    }
+    .offset-xxl-0 {
+        margin-left: 0;
+    }
+    .offset-xxl-1 {
+        margin-left: 8.3333333333%;
+    }
+    .offset-xxl-2 {
+        margin-left: 16.6666666667%;
+    }
+    .offset-xxl-3 {
+        margin-left: 25%;
+    }
+    .offset-xxl-4 {
+        margin-left: 33.3333333333%;
+    }
+    .offset-xxl-5 {
+        margin-left: 41.6666666667%;
+    }
+    .offset-xxl-6 {
+        margin-left: 50%;
+    }
+    .offset-xxl-7 {
+        margin-left: 58.3333333333%;
+    }
+    .offset-xxl-8 {
+        margin-left: 66.6666666667%;
+    }
+    .offset-xxl-9 {
+        margin-left: 75%;
+    }
+    .offset-xxl-10 {
+        margin-left: 83.3333333333%;
+    }
+    .offset-xxl-11 {
+        margin-left: 91.6666666667%;
+    }
+}
+
+.table {
+    width: 100%;
+    margin-bottom: 1rem;
+    color: #212529;
+}
+
+.table th,
+.table td {
+    padding: 0.75rem;
+    vertical-align: top;
+    border-top: 1px solid #dee2e6;
+}
+
+.table thead th {
+    vertical-align: bottom;
+    border-bottom: 2px solid #dee2e6;
+}
+
+.table tbody + tbody {
+    border-top: 2px solid #dee2e6;
+}
+
+.table-sm th,
+.table-sm td {
+    padding: 0.3rem;
+}
+
+.table-bordered {
+    border: 1px solid #dee2e6;
+}
+
+.table-bordered th,
+.table-bordered td {
+    border: 1px solid #dee2e6;
+}
+
+.table-bordered thead th,
+.table-bordered thead td {
+    border-bottom-width: 2px;
+}
+
+.table-borderless th,
+.table-borderless td,
+.table-borderless thead th,
+.table-borderless tbody + tbody {
+    border: 0;
+}
+
+.table-striped tbody tr:nth-of-type(odd) {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.table-hover tbody tr:hover {
+    color: #212529;
+    background-color: rgba(0, 0, 0, 0.075);
+}
+
+.table-primary,
+.table-primary > th,
+.table-primary > td {
+    background-color: #bebfda;
+}
+
+.table-primary th,
+.table-primary td,
+.table-primary thead th,
+.table-primary tbody + tbody {
+    border-color: #8788ba;
+}
+
+.table-hover .table-primary:hover {
+    background-color: #aeafd1;
+}
+
+.table-hover .table-primary:hover > td,
+.table-hover .table-primary:hover > th {
+    background-color: #aeafd1;
+}
+
+.table-secondary,
+.table-secondary > th,
+.table-secondary > td {
+    background-color: #c8d6fc;
+}
+
+.table-secondary th,
+.table-secondary td,
+.table-secondary thead th,
+.table-secondary tbody + tbody {
+    border-color: #99b3fa;
+}
+
+.table-hover .table-secondary:hover {
+    background-color: #b0c4fb;
+}
+
+.table-hover .table-secondary:hover > td,
+.table-hover .table-secondary:hover > th {
+    background-color: #b0c4fb;
+}
+
+.table-success,
+.table-success > th,
+.table-success > td {
+    background-color: #c1dec9;
+}
+
+.table-success th,
+.table-success td,
+.table-success thead th,
+.table-success tbody + tbody {
+    border-color: #8cc19b;
+}
+
+.table-hover .table-success:hover {
+    background-color: #b0d5bb;
+}
+
+.table-hover .table-success:hover > td,
+.table-hover .table-success:hover > th {
+    background-color: #b0d5bb;
+}
+
+.table-info,
+.table-info > th,
+.table-info > td {
+    background-color: #e6bdeb;
+}
+
+.table-info th,
+.table-info td,
+.table-info thead th,
+.table-info tbody + tbody {
+    border-color: #d084d9;
+}
+
+.table-hover .table-info:hover {
+    background-color: #dfa9e5;
+}
+
+.table-hover .table-info:hover > td,
+.table-hover .table-info:hover > th {
+    background-color: #dfa9e5;
+}
+
+.table-warning,
+.table-warning > th,
+.table-warning > td {
+    background-color: #ffeeba;
+}
+
+.table-warning th,
+.table-warning td,
+.table-warning thead th,
+.table-warning tbody + tbody {
+    border-color: #ffdf7e;
+}
+
+.table-hover .table-warning:hover {
+    background-color: #ffe8a1;
+}
+
+.table-hover .table-warning:hover > td,
+.table-hover .table-warning:hover > th {
+    background-color: #ffe8a1;
+}
+
+.table-danger,
+.table-danger > th,
+.table-danger > td {
+    background-color: #f9bec4;
+}
+
+.table-danger th,
+.table-danger td,
+.table-danger thead th,
+.table-danger tbody + tbody {
+    border-color: #f48691;
+}
+
+.table-hover .table-danger:hover {
+    background-color: #f7a7af;
+}
+
+.table-hover .table-danger:hover > td,
+.table-hover .table-danger:hover > th {
+    background-color: #f7a7af;
+}
+
+.table-light,
+.table-light > th,
+.table-light > td {
+    background-color: #f8fafd;
+}
+
+.table-light th,
+.table-light td,
+.table-light thead th,
+.table-light tbody + tbody {
+    border-color: #f2f5fb;
+}
+
+.table-hover .table-light:hover {
+    background-color: #e4ecf7;
+}
+
+.table-hover .table-light:hover > td,
+.table-hover .table-light:hover > th {
+    background-color: #e4ecf7;
+}
+
+.table-dark,
+.table-dark > th,
+.table-dark > td {
+    background-color: #babdc7;
+}
+
+.table-dark th,
+.table-dark td,
+.table-dark thead th,
+.table-dark tbody + tbody {
+    border-color: #808598;
+}
+
+.table-hover .table-dark:hover {
+    background-color: #acb0bc;
+}
+
+.table-hover .table-dark:hover > td,
+.table-hover .table-dark:hover > th {
+    background-color: #acb0bc;
+}
+
+.table-white,
+.table-white > th,
+.table-white > td {
+    background-color: white;
+}
+
+.table-white th,
+.table-white td,
+.table-white thead th,
+.table-white tbody + tbody {
+    border-color: white;
+}
+
+.table-hover .table-white:hover {
+    background-color: #f2f2f2;
+}
+
+.table-hover .table-white:hover > td,
+.table-hover .table-white:hover > th {
+    background-color: #f2f2f2;
+}
+
+.table-black,
+.table-black > th,
+.table-black > td {
+    background-color: #b8b8b8;
+}
+
+.table-black th,
+.table-black td,
+.table-black thead th,
+.table-black tbody + tbody {
+    border-color: #7a7a7a;
+}
+
+.table-hover .table-black:hover {
+    background-color: #ababab;
+}
+
+.table-hover .table-black:hover > td,
+.table-hover .table-black:hover > th {
+    background-color: #ababab;
+}
+
+.table-active,
+.table-active > th,
+.table-active > td {
+    background-color: rgba(0, 0, 0, 0.075);
+}
+
+.table-hover .table-active:hover {
+    background-color: rgba(0, 0, 0, 0.075);
+}
+
+.table-hover .table-active:hover > td,
+.table-hover .table-active:hover > th {
+    background-color: rgba(0, 0, 0, 0.075);
+}
+
+.table .thead-dark th {
+    color: #fff;
+    background-color: #343a40;
+    border-color: #454d55;
+}
+
+.table .thead-light th {
+    color: #495057;
+    background-color: #e9ecef;
+    border-color: #dee2e6;
+}
+
+.table-dark {
+    color: #fff;
+    background-color: #343a40;
+}
+
+.table-dark th,
+.table-dark td,
+.table-dark thead th {
+    border-color: #454d55;
+}
+
+.table-dark.table-bordered {
+    border: 0;
+}
+
+.table-dark.table-striped tbody tr:nth-of-type(odd) {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.table-dark.table-hover tbody tr:hover {
+    color: #fff;
+    background-color: rgba(255, 255, 255, 0.075);
+}
+
+@media (max-width: 479.98px) {
+    .table-responsive-sm {
+        display: block;
+        width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    .table-responsive-sm > .table-bordered {
+        border: 0;
+    }
+}
+
+@media (max-width: 719.98px) {
+    .table-responsive-md {
+        display: block;
+        width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    .table-responsive-md > .table-bordered {
+        border: 0;
+    }
+}
+
+@media (max-width: 959.98px) {
+    .table-responsive-lg {
+        display: block;
+        width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    .table-responsive-lg > .table-bordered {
+        border: 0;
+    }
+}
+
+@media (max-width: 1199.98px) {
+    .table-responsive-xl {
+        display: block;
+        width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    .table-responsive-xl > .table-bordered {
+        border: 0;
+    }
+}
+
+@media (max-width: 1439.98px) {
+    .table-responsive-xxl {
+        display: block;
+        width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    .table-responsive-xxl > .table-bordered {
+        border: 0;
+    }
+}
+
+.table-responsive {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.table-responsive > .table-bordered {
+    border: 0;
+}
+
+.form-control {
+    display: block;
+    width: 100%;
+    height: calc(1.5em + 1rem + 2px);
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid #777677;
+    border-radius: 0;
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .form-control {
+        transition: none;
+    }
+}
+
+.form-control::-ms-expand {
+    background-color: transparent;
+    border: 0;
+}
+
+.form-control:focus {
+    color: #495057;
+    background-color: #fff;
+    border-color: #0029F7;
+    outline: 0;
+    box-shadow: 0 0 0 2px rgba(0, 41, 247, 0.75);
+}
+
+.form-control::placeholder {
+    color: #495057;
+    opacity: 1;
+}
+
+.form-control:disabled, .form-control[readonly] {
+    background-color: #e9ecef;
+    opacity: 1;
+}
+
+select.form-control:focus::-ms-value {
+    color: #495057;
+    background-color: #fff;
+}
+
+.form-control-file,
+.form-control-range {
+    display: block;
+    width: 100%;
+}
+
+.col-form-label {
+    padding-top: calc(0.5rem + 1px);
+    padding-bottom: calc(0.5rem + 1px);
+    margin-bottom: 0;
+    font-size: inherit;
+    line-height: 1.5;
+}
+
+.col-form-label-lg {
+    padding-top: calc(0.5rem + 1px);
+    padding-bottom: calc(0.5rem + 1px);
+    font-size: 1.25rem;
+    line-height: 1.5;
+}
+
+.col-form-label-sm {
+    padding-top: calc(0.25rem + 1px);
+    padding-bottom: calc(0.25rem + 1px);
+    font-size: 0.875rem;
+    line-height: 1.5;
+}
+
+.form-control-plaintext {
+    display: block;
+    width: 100%;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    margin-bottom: 0;
+    line-height: 1.5;
+    color: #212529;
+    background-color: transparent;
+    border: solid transparent;
+    border-width: 1px 0;
+}
+
+.form-control-plaintext.form-control-sm, .form-control-plaintext.form-control-lg {
+    padding-right: 0;
+    padding-left: 0;
+}
+
+.form-control-sm {
+    height: calc(1.5em + 0.5rem + 2px);
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+}
+
+.form-control-lg {
+    height: calc(1.5em + 1rem + 2px);
+    padding: 0.5rem 1rem;
+    font-size: 1.25rem;
+    line-height: 1.5;
+}
+
+select.form-control[size], select.form-control[multiple] {
+    height: auto;
+}
+
+textarea.form-control {
+    height: auto;
+}
+
+.form-group {
+    margin-bottom: 3rem;
+}
+
+.form-text {
+    display: block;
+    margin-top: 0.25rem;
+}
+
+.form-row {
+    display: flex;
+    flex-wrap: wrap;
+    margin-right: -5px;
+    margin-left: -5px;
+}
+
+.form-row > .col,
+.form-row > [class*="col-"] {
+    padding-right: 5px;
+    padding-left: 5px;
+}
+
+.form-check {
+    position: relative;
+    display: block;
+    padding-left: 1.25rem;
+}
+
+.form-check-input {
+    position: absolute;
+    margin-top: 0.3rem;
+    margin-left: -1.25rem;
+}
+
+.form-check-input:disabled ~ .form-check-label {
+    color: #495057;
+}
+
+.form-check-label {
+    margin-bottom: 0;
+}
+
+.form-check-inline {
+    display: inline-flex;
+    align-items: center;
+    padding-left: 0;
+    margin-right: 0.75rem;
+}
+
+.form-check-inline .form-check-input {
+    position: static;
+    margin-top: 0;
+    margin-right: 0.3125rem;
+    margin-left: 0;
+}
+
+.invalid-feedback {
+    display: none;
+    width: 100%;
+    margin-top: 0.25rem;
+    font-size: 0.875rem;
+    color: #ea172b;
+}
+
+.invalid-tooltip {
+    position: absolute;
+    top: 100%;
+    z-index: 5;
+    display: none;
+    max-width: 100%;
+    padding: 0.25rem 0.5rem;
+    margin-top: .1rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    color: #fff;
+    background-color: rgba(234, 23, 43, 0.9);
+}
+
+.was-validated .form-control:invalid, .form-control.is-invalid {
+    border-color: #ea172b;
+}
+
+.was-validated .form-control:invalid:focus, .form-control.is-invalid:focus {
+    border-color: #ea172b;
+    box-shadow: 0 0 0 0.15rem rgba(234, 23, 43, 0.25);
+}
+
+.was-validated .form-control:invalid ~ .invalid-feedback,
+.was-validated .form-control:invalid ~ .invalid-tooltip, .form-control.is-invalid ~ .invalid-feedback,
+.form-control.is-invalid ~ .invalid-tooltip {
+    display: block;
+}
+
+.was-validated .custom-select:invalid, .was-validated select:invalid, .custom-select.is-invalid, select.is-invalid {
+    border-color: #ea172b;
+}
+
+.was-validated .custom-select:invalid:focus, .was-validated select:invalid:focus, .custom-select.is-invalid:focus, select.is-invalid:focus {
+    border-color: #ea172b;
+    box-shadow: 0 0 0 0.15rem rgba(234, 23, 43, 0.25);
+}
+
+.was-validated .custom-select:invalid ~ .invalid-feedback, .was-validated select:invalid ~ .invalid-feedback,
+.was-validated .custom-select:invalid ~ .invalid-tooltip,
+.was-validated select:invalid ~ .invalid-tooltip, .custom-select.is-invalid ~ .invalid-feedback, select.is-invalid ~ .invalid-feedback,
+.custom-select.is-invalid ~ .invalid-tooltip,
+select.is-invalid ~ .invalid-tooltip {
+    display: block;
+}
+
+.was-validated .form-control-file:invalid ~ .invalid-feedback,
+.was-validated .form-control-file:invalid ~ .invalid-tooltip, .form-control-file.is-invalid ~ .invalid-feedback,
+.form-control-file.is-invalid ~ .invalid-tooltip {
+    display: block;
+}
+
+.was-validated .form-check-input:invalid ~ .form-check-label, .form-check-input.is-invalid ~ .form-check-label {
+    color: #ea172b;
+}
+
+.was-validated .form-check-input:invalid ~ .invalid-feedback,
+.was-validated .form-check-input:invalid ~ .invalid-tooltip, .form-check-input.is-invalid ~ .invalid-feedback,
+.form-check-input.is-invalid ~ .invalid-tooltip {
+    display: block;
+}
+
+.was-validated .custom-control-input:invalid ~ .custom-control-label, .custom-control-input.is-invalid ~ .custom-control-label {
+    color: #ea172b;
+}
+
+.was-validated .custom-control-input:invalid ~ .custom-control-label::before, .custom-control-input.is-invalid ~ .custom-control-label::before {
+    border-color: #ea172b;
+}
+
+.was-validated .custom-control-input:invalid ~ .invalid-feedback,
+.was-validated .custom-control-input:invalid ~ .invalid-tooltip, .custom-control-input.is-invalid ~ .invalid-feedback,
+.custom-control-input.is-invalid ~ .invalid-tooltip {
+    display: block;
+}
+
+.was-validated .custom-control-input:invalid:checked ~ .custom-control-label::before, .custom-control-input.is-invalid:checked ~ .custom-control-label::before {
+    border-color: #ee4656;
+    background-color: #ee4656;
+}
+
+.was-validated .custom-control-input:invalid:focus ~ .custom-control-label::before, .custom-control-input.is-invalid:focus ~ .custom-control-label::before {
+    box-shadow: 0 0 0 0.15rem rgba(234, 23, 43, 0.25);
+}
+
+.was-validated .custom-control-input:invalid:focus:not(:checked) ~ .custom-control-label::before, .custom-control-input.is-invalid:focus:not(:checked) ~ .custom-control-label::before {
+    border-color: #ea172b;
+}
+
+.was-validated .custom-file-input:invalid ~ .custom-file-label, .custom-file-input.is-invalid ~ .custom-file-label {
+    border-color: #ea172b;
+}
+
+.was-validated .custom-file-input:invalid ~ .invalid-feedback,
+.was-validated .custom-file-input:invalid ~ .invalid-tooltip, .custom-file-input.is-invalid ~ .invalid-feedback,
+.custom-file-input.is-invalid ~ .invalid-tooltip {
+    display: block;
+}
+
+.was-validated .custom-file-input:invalid:focus ~ .custom-file-label, .custom-file-input.is-invalid:focus ~ .custom-file-label {
+    border-color: #ea172b;
+    box-shadow: 0 0 0 0.15rem rgba(234, 23, 43, 0.25);
+}
+
+.form-inline {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
+}
+
+.form-inline .form-check {
+    width: 100%;
+}
+
+@media (min-width: 480px) {
+    .form-inline label {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 0;
+    }
+    .form-inline .form-group {
+        display: flex;
+        flex: 0 0 auto;
+        flex-flow: row wrap;
+        align-items: center;
+        margin-bottom: 0;
+    }
+    .form-inline .form-control {
+        display: inline-block;
+        width: auto;
+        vertical-align: middle;
+    }
+    .form-inline .form-control-plaintext {
+        display: inline-block;
+    }
+    .form-inline .input-group,
+    .form-inline .custom-select,
+    .form-inline select {
+        width: auto;
+    }
+    .form-inline .form-check {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: auto;
+        padding-left: 0;
+    }
+    .form-inline .form-check-input {
+        position: relative;
+        flex-shrink: 0;
+        margin-top: 0;
+        margin-right: 0.25rem;
+        margin-left: 0;
+    }
+    .form-inline .custom-control {
+        align-items: center;
+        justify-content: center;
+    }
+    .form-inline .custom-control-label {
+        margin-bottom: 0;
+    }
+}
+
+.btn {
+    display: inline-block;
+    font-weight: 700;
+    color: #212529;
+    text-align: center;
+    vertical-align: middle;
+    user-select: none;
+    background-color: transparent;
+    border: 1px solid transparent;
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    line-height: 1.5;
+    border-radius: 0;
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .btn {
+        transition: none;
+    }
+}
+
+.btn:hover {
+    color: #212529;
+    text-decoration: none;
+}
+
+.btn:focus, .btn.focus {
+    outline: 0;
+    box-shadow: 0 0 0 2px rgba(0, 41, 247, 0.75);
+}
+
+.btn.disabled, .btn:disabled {
+    opacity: 0.65;
+}
+
+a.btn.disabled,
+fieldset:disabled a.btn {
+    pointer-events: none;
+}
+
+.btn-primary {
+    color: #fff;
+    background-color: #181A7B;
+    border-color: #181A7B;
+}
+
+.btn-primary:hover {
+    color: #fff;
+    background-color: #12135b;
+    border-color: #101150;
+}
+
+.btn-primary:focus, .btn-primary.focus {
+    box-shadow: 0 0 0 0.15rem rgba(59, 60, 143, 0.5);
+}
+
+.btn-primary.disabled, .btn-primary:disabled {
+    color: #fff;
+    background-color: #181A7B;
+    border-color: #181A7B;
+}
+
+.btn-primary:not(:disabled):not(.disabled):active, .btn-primary:not(:disabled):not(.disabled).active,
+.show > .btn-primary.dropdown-toggle {
+    color: #fff;
+    background-color: #101150;
+    border-color: #0e0f46;
+}
+
+.btn-primary:not(:disabled):not(.disabled):active:focus, .btn-primary:not(:disabled):not(.disabled).active:focus,
+.show > .btn-primary.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(59, 60, 143, 0.5);
+}
+
+.btn-secondary {
+    color: #fff;
+    background-color: #3B6CF6;
+    border-color: #3B6CF6;
+}
+
+.btn-secondary:hover {
+    color: #fff;
+    background-color: #1651f4;
+    border-color: #0b48f3;
+}
+
+.btn-secondary:focus, .btn-secondary.focus {
+    box-shadow: 0 0 0 0.15rem rgba(88, 130, 247, 0.5);
+}
+
+.btn-secondary.disabled, .btn-secondary:disabled {
+    color: #fff;
+    background-color: #3B6CF6;
+    border-color: #3B6CF6;
+}
+
+.btn-secondary:not(:disabled):not(.disabled):active, .btn-secondary:not(:disabled):not(.disabled).active,
+.show > .btn-secondary.dropdown-toggle {
+    color: #fff;
+    background-color: #0b48f3;
+    border-color: #0b44e7;
+}
+
+.btn-secondary:not(:disabled):not(.disabled):active:focus, .btn-secondary:not(:disabled):not(.disabled).active:focus,
+.show > .btn-secondary.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(88, 130, 247, 0.5);
+}
+
+.btn-success {
+    color: #fff;
+    background-color: #21883f;
+    border-color: #21883f;
+}
+
+.btn-success:hover {
+    color: #fff;
+    background-color: #1a6931;
+    border-color: #175f2c;
+}
+
+.btn-success:focus, .btn-success.focus {
+    box-shadow: 0 0 0 0.15rem rgba(66, 154, 92, 0.5);
+}
+
+.btn-success.disabled, .btn-success:disabled {
+    color: #fff;
+    background-color: #21883f;
+    border-color: #21883f;
+}
+
+.btn-success:not(:disabled):not(.disabled):active, .btn-success:not(:disabled):not(.disabled).active,
+.show > .btn-success.dropdown-toggle {
+    color: #fff;
+    background-color: #175f2c;
+    border-color: #155527;
+}
+
+.btn-success:not(:disabled):not(.disabled):active:focus, .btn-success:not(:disabled):not(.disabled).active:focus,
+.show > .btn-success.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(66, 154, 92, 0.5);
+}
+
+.btn-info {
+    color: #fff;
+    background-color: #A513B6;
+    border-color: #A513B6;
+}
+
+.btn-info:hover {
+    color: #fff;
+    background-color: #860f93;
+    border-color: #7b0e88;
+}
+
+.btn-info:focus, .btn-info.focus {
+    box-shadow: 0 0 0 0.15rem rgba(179, 54, 193, 0.5);
+}
+
+.btn-info.disabled, .btn-info:disabled {
+    color: #fff;
+    background-color: #A513B6;
+    border-color: #A513B6;
+}
+
+.btn-info:not(:disabled):not(.disabled):active, .btn-info:not(:disabled):not(.disabled).active,
+.show > .btn-info.dropdown-toggle {
+    color: #fff;
+    background-color: #7b0e88;
+    border-color: #710d7c;
+}
+
+.btn-info:not(:disabled):not(.disabled):active:focus, .btn-info:not(:disabled):not(.disabled).active:focus,
+.show > .btn-info.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(179, 54, 193, 0.5);
+}
+
+.btn-warning {
+    color: #212529;
+    background-color: #ffc107;
+    border-color: #ffc107;
+}
+
+.btn-warning:hover {
+    color: #212529;
+    background-color: #e0a800;
+    border-color: #d39e00;
+}
+
+.btn-warning:focus, .btn-warning.focus {
+    box-shadow: 0 0 0 0.15rem rgba(222, 170, 12, 0.5);
+}
+
+.btn-warning.disabled, .btn-warning:disabled {
+    color: #212529;
+    background-color: #ffc107;
+    border-color: #ffc107;
+}
+
+.btn-warning:not(:disabled):not(.disabled):active, .btn-warning:not(:disabled):not(.disabled).active,
+.show > .btn-warning.dropdown-toggle {
+    color: #212529;
+    background-color: #d39e00;
+    border-color: #c69500;
+}
+
+.btn-warning:not(:disabled):not(.disabled):active:focus, .btn-warning:not(:disabled):not(.disabled).active:focus,
+.show > .btn-warning.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(222, 170, 12, 0.5);
+}
+
+.btn-danger {
+    color: #fff;
+    background-color: #ea172b;
+    border-color: #ea172b;
+}
+
+.btn-danger:hover {
+    color: #fff;
+    background-color: #c91223;
+    border-color: #bd1121;
+}
+
+.btn-danger:focus, .btn-danger.focus {
+    box-shadow: 0 0 0 0.15rem rgba(237, 58, 75, 0.5);
+}
+
+.btn-danger.disabled, .btn-danger:disabled {
+    color: #fff;
+    background-color: #ea172b;
+    border-color: #ea172b;
+}
+
+.btn-danger:not(:disabled):not(.disabled):active, .btn-danger:not(:disabled):not(.disabled).active,
+.show > .btn-danger.dropdown-toggle {
+    color: #fff;
+    background-color: #bd1121;
+    border-color: #b1101f;
+}
+
+.btn-danger:not(:disabled):not(.disabled):active:focus, .btn-danger:not(:disabled):not(.disabled).active:focus,
+.show > .btn-danger.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(237, 58, 75, 0.5);
+}
+
+.btn-light {
+    color: #212529;
+    background-color: #e6ecf7;
+    border-color: #e6ecf7;
+}
+
+.btn-light:hover {
+    color: #212529;
+    background-color: #c9d6ee;
+    border-color: #bfcfeb;
+}
+
+.btn-light:focus, .btn-light.focus {
+    box-shadow: 0 0 0 0.15rem rgba(200, 206, 216, 0.5);
+}
+
+.btn-light.disabled, .btn-light:disabled {
+    color: #212529;
+    background-color: #e6ecf7;
+    border-color: #e6ecf7;
+}
+
+.btn-light:not(:disabled):not(.disabled):active, .btn-light:not(:disabled):not(.disabled).active,
+.show > .btn-light.dropdown-toggle {
+    color: #212529;
+    background-color: #bfcfeb;
+    border-color: #b6c7e8;
+}
+
+.btn-light:not(:disabled):not(.disabled):active:focus, .btn-light:not(:disabled):not(.disabled).active:focus,
+.show > .btn-light.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(200, 206, 216, 0.5);
+}
+
+.btn-dark {
+    color: #fff;
+    background-color: #0A1438;
+    border-color: #0A1438;
+}
+
+.btn-dark:hover {
+    color: #fff;
+    background-color: #040818;
+    border-color: #02050d;
+}
+
+.btn-dark:focus, .btn-dark.focus {
+    box-shadow: 0 0 0 0.15rem rgba(47, 55, 86, 0.5);
+}
+
+.btn-dark.disabled, .btn-dark:disabled {
+    color: #fff;
+    background-color: #0A1438;
+    border-color: #0A1438;
+}
+
+.btn-dark:not(:disabled):not(.disabled):active, .btn-dark:not(:disabled):not(.disabled).active,
+.show > .btn-dark.dropdown-toggle {
+    color: #fff;
+    background-color: #02050d;
+    border-color: #000102;
+}
+
+.btn-dark:not(:disabled):not(.disabled):active:focus, .btn-dark:not(:disabled):not(.disabled).active:focus,
+.show > .btn-dark.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(47, 55, 86, 0.5);
+}
+
+.btn-white {
+    color: #212529;
+    background-color: #fff;
+    border-color: #fff;
+}
+
+.btn-white:hover {
+    color: #212529;
+    background-color: #ececec;
+    border-color: #e6e6e6;
+}
+
+.btn-white:focus, .btn-white.focus {
+    box-shadow: 0 0 0 0.15rem rgba(222, 222, 223, 0.5);
+}
+
+.btn-white.disabled, .btn-white:disabled {
+    color: #212529;
+    background-color: #fff;
+    border-color: #fff;
+}
+
+.btn-white:not(:disabled):not(.disabled):active, .btn-white:not(:disabled):not(.disabled).active,
+.show > .btn-white.dropdown-toggle {
+    color: #212529;
+    background-color: #e6e6e6;
+    border-color: #dfdfdf;
+}
+
+.btn-white:not(:disabled):not(.disabled):active:focus, .btn-white:not(:disabled):not(.disabled).active:focus,
+.show > .btn-white.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(222, 222, 223, 0.5);
+}
+
+.btn-black {
+    color: #fff;
+    background-color: #000;
+    border-color: #000;
+}
+
+.btn-black:hover {
+    color: #fff;
+    background-color: black;
+    border-color: black;
+}
+
+.btn-black:focus, .btn-black.focus {
+    box-shadow: 0 0 0 0.15rem rgba(38, 38, 38, 0.5);
+}
+
+.btn-black.disabled, .btn-black:disabled {
+    color: #fff;
+    background-color: #000;
+    border-color: #000;
+}
+
+.btn-black:not(:disabled):not(.disabled):active, .btn-black:not(:disabled):not(.disabled).active,
+.show > .btn-black.dropdown-toggle {
+    color: #fff;
+    background-color: black;
+    border-color: black;
+}
+
+.btn-black:not(:disabled):not(.disabled):active:focus, .btn-black:not(:disabled):not(.disabled).active:focus,
+.show > .btn-black.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(38, 38, 38, 0.5);
+}
+
+.btn-outline-primary {
+    color: #181A7B;
+    border-color: #181A7B;
+}
+
+.btn-outline-primary:hover {
+    color: #fff;
+    background-color: #181A7B;
+    border-color: #181A7B;
+}
+
+.btn-outline-primary:focus, .btn-outline-primary.focus {
+    box-shadow: 0 0 0 0.15rem rgba(24, 26, 123, 0.5);
+}
+
+.btn-outline-primary.disabled, .btn-outline-primary:disabled {
+    color: #181A7B;
+    background-color: transparent;
+}
+
+.btn-outline-primary:not(:disabled):not(.disabled):active, .btn-outline-primary:not(:disabled):not(.disabled).active,
+.show > .btn-outline-primary.dropdown-toggle {
+    color: #fff;
+    background-color: #181A7B;
+    border-color: #181A7B;
+}
+
+.btn-outline-primary:not(:disabled):not(.disabled):active:focus, .btn-outline-primary:not(:disabled):not(.disabled).active:focus,
+.show > .btn-outline-primary.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(24, 26, 123, 0.5);
+}
+
+.btn-outline-secondary {
+    color: #3B6CF6;
+    border-color: #3B6CF6;
+}
+
+.btn-outline-secondary:hover {
+    color: #fff;
+    background-color: #3B6CF6;
+    border-color: #3B6CF6;
+}
+
+.btn-outline-secondary:focus, .btn-outline-secondary.focus {
+    box-shadow: 0 0 0 0.15rem rgba(59, 108, 246, 0.5);
+}
+
+.btn-outline-secondary.disabled, .btn-outline-secondary:disabled {
+    color: #3B6CF6;
+    background-color: transparent;
+}
+
+.btn-outline-secondary:not(:disabled):not(.disabled):active, .btn-outline-secondary:not(:disabled):not(.disabled).active,
+.show > .btn-outline-secondary.dropdown-toggle {
+    color: #fff;
+    background-color: #3B6CF6;
+    border-color: #3B6CF6;
+}
+
+.btn-outline-secondary:not(:disabled):not(.disabled):active:focus, .btn-outline-secondary:not(:disabled):not(.disabled).active:focus,
+.show > .btn-outline-secondary.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(59, 108, 246, 0.5);
+}
+
+.btn-outline-success {
+    color: #21883f;
+    border-color: #21883f;
+}
+
+.btn-outline-success:hover {
+    color: #fff;
+    background-color: #21883f;
+    border-color: #21883f;
+}
+
+.btn-outline-success:focus, .btn-outline-success.focus {
+    box-shadow: 0 0 0 0.15rem rgba(33, 136, 63, 0.5);
+}
+
+.btn-outline-success.disabled, .btn-outline-success:disabled {
+    color: #21883f;
+    background-color: transparent;
+}
+
+.btn-outline-success:not(:disabled):not(.disabled):active, .btn-outline-success:not(:disabled):not(.disabled).active,
+.show > .btn-outline-success.dropdown-toggle {
+    color: #fff;
+    background-color: #21883f;
+    border-color: #21883f;
+}
+
+.btn-outline-success:not(:disabled):not(.disabled):active:focus, .btn-outline-success:not(:disabled):not(.disabled).active:focus,
+.show > .btn-outline-success.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(33, 136, 63, 0.5);
+}
+
+.btn-outline-info {
+    color: #A513B6;
+    border-color: #A513B6;
+}
+
+.btn-outline-info:hover {
+    color: #fff;
+    background-color: #A513B6;
+    border-color: #A513B6;
+}
+
+.btn-outline-info:focus, .btn-outline-info.focus {
+    box-shadow: 0 0 0 0.15rem rgba(165, 19, 182, 0.5);
+}
+
+.btn-outline-info.disabled, .btn-outline-info:disabled {
+    color: #A513B6;
+    background-color: transparent;
+}
+
+.btn-outline-info:not(:disabled):not(.disabled):active, .btn-outline-info:not(:disabled):not(.disabled).active,
+.show > .btn-outline-info.dropdown-toggle {
+    color: #fff;
+    background-color: #A513B6;
+    border-color: #A513B6;
+}
+
+.btn-outline-info:not(:disabled):not(.disabled):active:focus, .btn-outline-info:not(:disabled):not(.disabled).active:focus,
+.show > .btn-outline-info.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(165, 19, 182, 0.5);
+}
+
+.btn-outline-warning {
+    color: #ffc107;
+    border-color: #ffc107;
+}
+
+.btn-outline-warning:hover {
+    color: #212529;
+    background-color: #ffc107;
+    border-color: #ffc107;
+}
+
+.btn-outline-warning:focus, .btn-outline-warning.focus {
+    box-shadow: 0 0 0 0.15rem rgba(255, 193, 7, 0.5);
+}
+
+.btn-outline-warning.disabled, .btn-outline-warning:disabled {
+    color: #ffc107;
+    background-color: transparent;
+}
+
+.btn-outline-warning:not(:disabled):not(.disabled):active, .btn-outline-warning:not(:disabled):not(.disabled).active,
+.show > .btn-outline-warning.dropdown-toggle {
+    color: #212529;
+    background-color: #ffc107;
+    border-color: #ffc107;
+}
+
+.btn-outline-warning:not(:disabled):not(.disabled):active:focus, .btn-outline-warning:not(:disabled):not(.disabled).active:focus,
+.show > .btn-outline-warning.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(255, 193, 7, 0.5);
+}
+
+.btn-outline-danger {
+    color: #ea172b;
+    border-color: #ea172b;
+}
+
+.btn-outline-danger:hover {
+    color: #fff;
+    background-color: #ea172b;
+    border-color: #ea172b;
+}
+
+.btn-outline-danger:focus, .btn-outline-danger.focus {
+    box-shadow: 0 0 0 0.15rem rgba(234, 23, 43, 0.5);
+}
+
+.btn-outline-danger.disabled, .btn-outline-danger:disabled {
+    color: #ea172b;
+    background-color: transparent;
+}
+
+.btn-outline-danger:not(:disabled):not(.disabled):active, .btn-outline-danger:not(:disabled):not(.disabled).active,
+.show > .btn-outline-danger.dropdown-toggle {
+    color: #fff;
+    background-color: #ea172b;
+    border-color: #ea172b;
+}
+
+.btn-outline-danger:not(:disabled):not(.disabled):active:focus, .btn-outline-danger:not(:disabled):not(.disabled).active:focus,
+.show > .btn-outline-danger.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(234, 23, 43, 0.5);
+}
+
+.btn-outline-light {
+    color: #e6ecf7;
+    border-color: #e6ecf7;
+}
+
+.btn-outline-light:hover {
+    color: #212529;
+    background-color: #e6ecf7;
+    border-color: #e6ecf7;
+}
+
+.btn-outline-light:focus, .btn-outline-light.focus {
+    box-shadow: 0 0 0 0.15rem rgba(230, 236, 247, 0.5);
+}
+
+.btn-outline-light.disabled, .btn-outline-light:disabled {
+    color: #e6ecf7;
+    background-color: transparent;
+}
+
+.btn-outline-light:not(:disabled):not(.disabled):active, .btn-outline-light:not(:disabled):not(.disabled).active,
+.show > .btn-outline-light.dropdown-toggle {
+    color: #212529;
+    background-color: #e6ecf7;
+    border-color: #e6ecf7;
+}
+
+.btn-outline-light:not(:disabled):not(.disabled):active:focus, .btn-outline-light:not(:disabled):not(.disabled).active:focus,
+.show > .btn-outline-light.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(230, 236, 247, 0.5);
+}
+
+.btn-outline-dark {
+    color: #0A1438;
+    border-color: #0A1438;
+}
+
+.btn-outline-dark:hover {
+    color: #fff;
+    background-color: #0A1438;
+    border-color: #0A1438;
+}
+
+.btn-outline-dark:focus, .btn-outline-dark.focus {
+    box-shadow: 0 0 0 0.15rem rgba(10, 20, 56, 0.5);
+}
+
+.btn-outline-dark.disabled, .btn-outline-dark:disabled {
+    color: #0A1438;
+    background-color: transparent;
+}
+
+.btn-outline-dark:not(:disabled):not(.disabled):active, .btn-outline-dark:not(:disabled):not(.disabled).active,
+.show > .btn-outline-dark.dropdown-toggle {
+    color: #fff;
+    background-color: #0A1438;
+    border-color: #0A1438;
+}
+
+.btn-outline-dark:not(:disabled):not(.disabled):active:focus, .btn-outline-dark:not(:disabled):not(.disabled).active:focus,
+.show > .btn-outline-dark.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(10, 20, 56, 0.5);
+}
+
+.btn-outline-white {
+    color: #fff;
+    border-color: #fff;
+}
+
+.btn-outline-white:hover {
+    color: #212529;
+    background-color: #fff;
+    border-color: #fff;
+}
+
+.btn-outline-white:focus, .btn-outline-white.focus {
+    box-shadow: 0 0 0 0.15rem rgba(255, 255, 255, 0.5);
+}
+
+.btn-outline-white.disabled, .btn-outline-white:disabled {
+    color: #fff;
+    background-color: transparent;
+}
+
+.btn-outline-white:not(:disabled):not(.disabled):active, .btn-outline-white:not(:disabled):not(.disabled).active,
+.show > .btn-outline-white.dropdown-toggle {
+    color: #212529;
+    background-color: #fff;
+    border-color: #fff;
+}
+
+.btn-outline-white:not(:disabled):not(.disabled):active:focus, .btn-outline-white:not(:disabled):not(.disabled).active:focus,
+.show > .btn-outline-white.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(255, 255, 255, 0.5);
+}
+
+.btn-outline-black {
+    color: #000;
+    border-color: #000;
+}
+
+.btn-outline-black:hover {
+    color: #fff;
+    background-color: #000;
+    border-color: #000;
+}
+
+.btn-outline-black:focus, .btn-outline-black.focus {
+    box-shadow: 0 0 0 0.15rem rgba(0, 0, 0, 0.5);
+}
+
+.btn-outline-black.disabled, .btn-outline-black:disabled {
+    color: #000;
+    background-color: transparent;
+}
+
+.btn-outline-black:not(:disabled):not(.disabled):active, .btn-outline-black:not(:disabled):not(.disabled).active,
+.show > .btn-outline-black.dropdown-toggle {
+    color: #fff;
+    background-color: #000;
+    border-color: #000;
+}
+
+.btn-outline-black:not(:disabled):not(.disabled):active:focus, .btn-outline-black:not(:disabled):not(.disabled).active:focus,
+.show > .btn-outline-black.dropdown-toggle:focus {
+    box-shadow: 0 0 0 0.15rem rgba(0, 0, 0, 0.5);
+}
+
+.btn-link {
+    font-weight: 400;
+    color: #0029F7;
+    text-decoration: none;
+}
+
+.btn-link:hover {
+    color: #001cab;
+    text-decoration: none;
+}
+
+.btn-link:focus, .btn-link.focus {
+    text-decoration: none;
+    box-shadow: none;
+}
+
+.btn-link:disabled, .btn-link.disabled {
+    color: #777677;
+    pointer-events: none;
+}
+
+.btn-lg, .btn-group-lg > .btn {
+    padding: 0.5rem 1rem;
+    font-size: 1.25rem;
+    line-height: 1.5;
+    border-radius: 0;
+}
+
+.btn-sm, .btn-group-sm > .btn {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    border-radius: 0;
+}
+
+.btn-block {
+    display: block;
+    width: 100%;
+}
+
+.btn-block + .btn-block {
+    margin-top: 0.5rem;
+}
+
+input[type="submit"].btn-block,
+input[type="reset"].btn-block,
+input[type="button"].btn-block {
+    width: 100%;
+}
+
+.fade {
+    transition: opacity 0.15s linear;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .fade {
+        transition: none;
+    }
+}
+
+.fade:not(.show) {
+    opacity: 0;
+}
+
+.collapse:not(.show) {
+    display: none;
+}
+
+.collapsing {
+    position: relative;
+    height: 0;
+    overflow: hidden;
+    transition: height 0.35s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .collapsing {
+        transition: none;
+    }
+}
+
+.dropup,
+.dropright,
+.dropdown,
+.dropleft {
+    position: relative;
+}
+
+.dropdown-toggle {
+    white-space: nowrap;
+}
+
+.dropdown-toggle::after {
+    display: inline-block;
+    margin-left: 0.255em;
+    vertical-align: 0.255em;
+    content: "";
+    border-top: 0.3em solid;
+    border-right: 0.3em solid transparent;
+    border-bottom: 0;
+    border-left: 0.3em solid transparent;
+}
+
+.dropdown-toggle:empty::after {
+    margin-left: 0;
+}
+
+.dropdown-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1000;
+    display: none;
+    float: left;
+    min-width: 10rem;
+    padding: 0.5rem 0;
+    margin: 0.125rem 0 0;
+    font-size: 1rem;
+    color: #212529;
+    text-align: left;
+    list-style: none;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+.dropdown-menu-left {
+    right: auto;
+    left: 0;
+}
+
+.dropdown-menu-right {
+    right: 0;
+    left: auto;
+}
+
+@media (min-width: 480px) {
+    .dropdown-menu-sm-left {
+        right: auto;
+        left: 0;
+    }
+    .dropdown-menu-sm-right {
+        right: 0;
+        left: auto;
+    }
+}
+
+@media (min-width: 720px) {
+    .dropdown-menu-md-left {
+        right: auto;
+        left: 0;
+    }
+    .dropdown-menu-md-right {
+        right: 0;
+        left: auto;
+    }
+}
+
+@media (min-width: 960px) {
+    .dropdown-menu-lg-left {
+        right: auto;
+        left: 0;
+    }
+    .dropdown-menu-lg-right {
+        right: 0;
+        left: auto;
+    }
+}
+
+@media (min-width: 1200px) {
+    .dropdown-menu-xl-left {
+        right: auto;
+        left: 0;
+    }
+    .dropdown-menu-xl-right {
+        right: 0;
+        left: auto;
+    }
+}
+
+@media (min-width: 1440px) {
+    .dropdown-menu-xxl-left {
+        right: auto;
+        left: 0;
+    }
+    .dropdown-menu-xxl-right {
+        right: 0;
+        left: auto;
+    }
+}
+
+.dropup .dropdown-menu {
+    top: auto;
+    bottom: 100%;
+    margin-top: 0;
+    margin-bottom: 0.125rem;
+}
+
+.dropup .dropdown-toggle::after {
+    display: inline-block;
+    margin-left: 0.255em;
+    vertical-align: 0.255em;
+    content: "";
+    border-top: 0;
+    border-right: 0.3em solid transparent;
+    border-bottom: 0.3em solid;
+    border-left: 0.3em solid transparent;
+}
+
+.dropup .dropdown-toggle:empty::after {
+    margin-left: 0;
+}
+
+.dropright .dropdown-menu {
+    top: 0;
+    right: auto;
+    left: 100%;
+    margin-top: 0;
+    margin-left: 0.125rem;
+}
+
+.dropright .dropdown-toggle::after {
+    display: inline-block;
+    margin-left: 0.255em;
+    vertical-align: 0.255em;
+    content: "";
+    border-top: 0.3em solid transparent;
+    border-right: 0;
+    border-bottom: 0.3em solid transparent;
+    border-left: 0.3em solid;
+}
+
+.dropright .dropdown-toggle:empty::after {
+    margin-left: 0;
+}
+
+.dropright .dropdown-toggle::after {
+    vertical-align: 0;
+}
+
+.dropleft .dropdown-menu {
+    top: 0;
+    right: 100%;
+    left: auto;
+    margin-top: 0;
+    margin-right: 0.125rem;
+}
+
+.dropleft .dropdown-toggle::after {
+    display: inline-block;
+    margin-left: 0.255em;
+    vertical-align: 0.255em;
+    content: "";
+}
+
+.dropleft .dropdown-toggle::after {
+    display: none;
+}
+
+.dropleft .dropdown-toggle::before {
+    display: inline-block;
+    margin-right: 0.255em;
+    vertical-align: 0.255em;
+    content: "";
+    border-top: 0.3em solid transparent;
+    border-right: 0.3em solid;
+    border-bottom: 0.3em solid transparent;
+}
+
+.dropleft .dropdown-toggle:empty::after {
+    margin-left: 0;
+}
+
+.dropleft .dropdown-toggle::before {
+    vertical-align: 0;
+}
+
+.dropdown-menu[x-placement^="top"], .dropdown-menu[x-placement^="right"], .dropdown-menu[x-placement^="bottom"], .dropdown-menu[x-placement^="left"] {
+    right: auto;
+    bottom: auto;
+}
+
+.dropdown-divider {
+    height: 0;
+    margin: 0.5rem 0;
+    overflow: hidden;
+    border-top: 1px solid #e9ecef;
+}
+
+.dropdown-item {
+    display: block;
+    width: 100%;
+    padding: 0.25rem 1.5rem;
+    clear: both;
+    font-weight: 400;
+    color: #212529;
+    text-align: inherit;
+    white-space: nowrap;
+    background-color: transparent;
+    border: 0;
+}
+
+.dropdown-item:hover, .dropdown-item:focus {
+    color: #16181b;
+    text-decoration: none;
+    background-color: #F5F5F5;
+}
+
+.dropdown-item.active, .dropdown-item:active {
+    color: #212529;
+    text-decoration: none;
+    background-color: #A513B6;
+}
+
+.dropdown-item.disabled, .dropdown-item:disabled {
+    color: #777677;
+    pointer-events: none;
+    background-color: transparent;
+}
+
+.dropdown-menu.show {
+    display: block;
+}
+
+.dropdown-header {
+    display: block;
+    padding: 0.5rem 1.5rem;
+    margin-bottom: 0;
+    font-size: 0.875rem;
+    color: #495057;
+    white-space: nowrap;
+}
+
+.dropdown-item-text {
+    display: block;
+    padding: 0.25rem 1.5rem;
+    color: #212529;
+}
+
+.btn-group,
+.btn-group-vertical {
+    position: relative;
+    display: inline-flex;
+    vertical-align: middle;
+}
+
+.btn-group > .btn,
+.btn-group-vertical > .btn {
+    position: relative;
+    flex: 1 1 auto;
+}
+
+.btn-group > .btn:hover,
+.btn-group-vertical > .btn:hover {
+    z-index: 1;
+}
+
+.btn-group > .btn:focus, .btn-group > .btn:active, .btn-group > .btn.active,
+.btn-group-vertical > .btn:focus,
+.btn-group-vertical > .btn:active,
+.btn-group-vertical > .btn.active {
+    z-index: 1;
+}
+
+.btn-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+}
+
+.btn-toolbar .input-group {
+    width: auto;
+}
+
+.btn-group > .btn:not(:first-child),
+.btn-group > .btn-group:not(:first-child) {
+    margin-left: -1px;
+}
+
+.dropdown-toggle-split {
+    padding-right: 0.75rem;
+    padding-left: 0.75rem;
+}
+
+.dropdown-toggle-split::after,
+.dropup .dropdown-toggle-split::after,
+.dropright .dropdown-toggle-split::after {
+    margin-left: 0;
+}
+
+.dropleft .dropdown-toggle-split::before {
+    margin-right: 0;
+}
+
+.btn-sm + .dropdown-toggle-split, .btn-group-sm > .btn + .dropdown-toggle-split {
+    padding-right: 0.375rem;
+    padding-left: 0.375rem;
+}
+
+.btn-lg + .dropdown-toggle-split, .btn-group-lg > .btn + .dropdown-toggle-split {
+    padding-right: 0.75rem;
+    padding-left: 0.75rem;
+}
+
+.btn-group-vertical {
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+}
+
+.btn-group-vertical > .btn,
+.btn-group-vertical > .btn-group {
+    width: 100%;
+}
+
+.btn-group-vertical > .btn:not(:first-child),
+.btn-group-vertical > .btn-group:not(:first-child) {
+    margin-top: -1px;
+}
+
+.btn-group-toggle > .btn,
+.btn-group-toggle > .btn-group > .btn {
+    margin-bottom: 0;
+}
+
+.btn-group-toggle > .btn input[type="radio"],
+.btn-group-toggle > .btn input[type="checkbox"],
+.btn-group-toggle > .btn-group > .btn input[type="radio"],
+.btn-group-toggle > .btn-group > .btn input[type="checkbox"] {
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    pointer-events: none;
+}
+
+.input-group {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    width: 100%;
+}
+
+.input-group > .form-control,
+.input-group > .form-control-plaintext,
+.input-group > .custom-select,
+.input-group > select,
+.input-group > .custom-file {
+    position: relative;
+    flex: 1 1 auto;
+    width: 1%;
+    margin-bottom: 0;
+}
+
+.input-group > .form-control + .form-control,
+.input-group > .form-control + .custom-select,
+.input-group > .form-control + select,
+.input-group > .form-control + .custom-file,
+.input-group > .form-control-plaintext + .form-control,
+.input-group > .form-control-plaintext + .custom-select,
+.input-group > .form-control-plaintext + select,
+.input-group > .form-control-plaintext + .custom-file,
+.input-group > .custom-select + .form-control,
+.input-group > select + .form-control,
+.input-group > .custom-select + .custom-select,
+.input-group > select + .custom-select,
+.input-group > .custom-select + select,
+.input-group > select + select,
+.input-group > .custom-select + .custom-file,
+.input-group > select + .custom-file,
+.input-group > .custom-file + .form-control,
+.input-group > .custom-file + .custom-select,
+.input-group > .custom-file + select,
+.input-group > .custom-file + .custom-file {
+    margin-left: -1px;
+}
+
+.input-group > .form-control:focus,
+.input-group > .custom-select:focus,
+.input-group > select:focus,
+.input-group > .custom-file .custom-file-input:focus ~ .custom-file-label {
+    z-index: 3;
+}
+
+.input-group > .custom-file .custom-file-input:focus {
+    z-index: 4;
+}
+
+.input-group > .custom-file {
+    display: flex;
+    align-items: center;
+}
+
+.input-group-prepend,
+.input-group-append {
+    display: flex;
+}
+
+.input-group-prepend .btn,
+.input-group-append .btn {
+    position: relative;
+    z-index: 2;
+}
+
+.input-group-prepend .btn:focus,
+.input-group-append .btn:focus {
+    z-index: 3;
+}
+
+.input-group-prepend .btn + .btn,
+.input-group-prepend .btn + .input-group-text,
+.input-group-prepend .input-group-text + .input-group-text,
+.input-group-prepend .input-group-text + .btn,
+.input-group-append .btn + .btn,
+.input-group-append .btn + .input-group-text,
+.input-group-append .input-group-text + .input-group-text,
+.input-group-append .input-group-text + .btn {
+    margin-left: -1px;
+}
+
+.input-group-prepend {
+    margin-right: -1px;
+}
+
+.input-group-append {
+    margin-left: -1px;
+}
+
+.input-group-text {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    margin-bottom: 0;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    text-align: center;
+    white-space: nowrap;
+    background-color: #e9ecef;
+    border: 1px solid #777677;
+}
+
+.input-group-text input[type="radio"],
+.input-group-text input[type="checkbox"] {
+    margin-top: 0;
+}
+
+.input-group-lg > .form-control:not(textarea),
+.input-group-lg > .custom-select,
+.input-group-lg > select {
+    height: calc(1.5em + 1rem + 2px);
+}
+
+.input-group-lg > .form-control,
+.input-group-lg > .custom-select,
+.input-group-lg > select,
+.input-group-lg > .input-group-prepend > .input-group-text,
+.input-group-lg > .input-group-append > .input-group-text,
+.input-group-lg > .input-group-prepend > .btn,
+.input-group-lg > .input-group-append > .btn {
+    padding: 0.5rem 1rem;
+    font-size: 1.25rem;
+    line-height: 1.5;
+}
+
+.input-group-sm > .form-control:not(textarea),
+.input-group-sm > .custom-select,
+.input-group-sm > select {
+    height: calc(1.5em + 0.5rem + 2px);
+}
+
+.input-group-sm > .form-control,
+.input-group-sm > .custom-select,
+.input-group-sm > select,
+.input-group-sm > .input-group-prepend > .input-group-text,
+.input-group-sm > .input-group-append > .input-group-text,
+.input-group-sm > .input-group-prepend > .btn,
+.input-group-sm > .input-group-append > .btn {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+}
+
+
+.input-group-lg > .custom-select,
+.input-group-lg > select,
+.input-group-sm > .custom-select,
+.input-group-sm > select {
+    padding-right: 2rem;
+}
+
+.custom-control {
+    position: relative;
+    display: block;
+    min-height: 1.5rem;
+    padding-left: 1.5rem;
+}
+
+.custom-control-inline {
+    display: inline-flex;
+    margin-right: 1rem;
+}
+
+.custom-control-input {
+    position: absolute;
+    z-index: -1;
+    opacity: 0;
+}
+
+.custom-control-input:checked ~ .custom-control-label::before {
+    color: white;
+    border-color: #1239ff;
+    background-color: #1239ff;
+}
+
+.custom-control-input:focus ~ .custom-control-label::before {
+    box-shadow: 0 0 0 2px rgba(0, 41, 247, 0.75);
+}
+
+.custom-control-input:focus:not(:checked) ~ .custom-control-label::before {
+    border-color: #0029F7;
+}
+
+.custom-control-input:not(:disabled):active ~ .custom-control-label::before {
+    color: #fff;
+    background-color: #abb9ff;
+    border-color: #abb9ff;
+}
+
+.custom-control-input:disabled ~ .custom-control-label {
+    color: #777677;
+}
+
+.custom-control-input:disabled ~ .custom-control-label::before {
+    background-color: #e9ecef;
+}
+
+.custom-control-label {
+    position: relative;
+    margin-bottom: 0;
+    vertical-align: top;
+}
+
+.custom-control-label::before {
+    position: absolute;
+    top: 0.25rem;
+    left: -1.5rem;
+    display: block;
+    width: 1rem;
+    height: 1rem;
+    pointer-events: none;
+    content: "";
+    background-color: #fff;
+    border: #adb5bd solid 1px;
+}
+
+.custom-control-label::after {
+    position: absolute;
+    top: 0.25rem;
+    left: -1.5rem;
+    display: block;
+    width: 1rem;
+    height: 1rem;
+    content: "";
+    background: no-repeat 50% / 50% 50%;
+}
+
+.custom-checkbox .custom-control-input:checked ~ .custom-control-label::after {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='white' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3e%3c/svg%3e");
+}
+
+.custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::before {
+    border-color: #A513B6;
+    background-color: #A513B6;
+}
+
+.custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::after {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3e%3cpath stroke='white' d='M0 2h4'/%3e%3c/svg%3e");
+}
+
+.custom-checkbox .custom-control-input:disabled:checked ~ .custom-control-label::before {
+    background-color: rgba(24, 26, 123, 0.5);
+}
+
+.custom-checkbox .custom-control-input:disabled:indeterminate ~ .custom-control-label::before {
+    background-color: rgba(24, 26, 123, 0.5);
+}
+
+.custom-radio .custom-control-label::before {
+    border-radius: 50%;
+}
+
+.custom-radio .custom-control-input:checked ~ .custom-control-label::after {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='white'/%3e%3c/svg%3e");
+}
+
+.custom-radio .custom-control-input:disabled:checked ~ .custom-control-label::before {
+    background-color: rgba(24, 26, 123, 0.5);
+}
+
+.custom-switch {
+    padding-left: 2.25rem;
+}
+
+.custom-switch .custom-control-label::before {
+    left: -2.25rem;
+    width: 1.75rem;
+    pointer-events: all;
+    border-radius: 0.5rem;
+}
+
+.custom-switch .custom-control-label::after {
+    top: calc(0.25rem + 2px);
+    left: calc(-2.25rem + 2px);
+    width: calc(1rem - 4px);
+    height: calc(1rem - 4px);
+    background-color: #adb5bd;
+    border-radius: 0.5rem;
+    transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .custom-switch .custom-control-label::after {
+        transition: none;
+    }
+}
+
+.custom-switch .custom-control-input:checked ~ .custom-control-label::after {
+    background-color: #fff;
+    transform: translateX(0.75rem);
+}
+
+.custom-switch .custom-control-input:disabled:checked ~ .custom-control-label::before {
+    background-color: rgba(24, 26, 123, 0.5);
+}
+
+.custom-select, select {
+    display: inline-block;
+    width: 100%;
+    height: calc(1.5em + 1rem + 2px);
+    padding: 0.5rem 2rem 0.5rem 1rem;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    vertical-align: middle;
+    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 1rem center/8px 10px;
+    background-color: #fff;
+    border: 1px solid #777677;
+    border-radius: 0;
+    appearance: none;
+}
+
+.custom-select:focus, select:focus {
+    border-color: #0029F7;
+    outline: 0;
+    box-shadow: 0 0 0 0.15rem rgba(165, 19, 182, 0.25);
+}
+
+.custom-select:focus::-ms-value, select:focus::-ms-value {
+    color: #495057;
+    background-color: #fff;
+}
+
+.custom-select[multiple], select[multiple], .custom-select[size]:not([size="1"]), select[size]:not([size="1"]) {
+    height: auto;
+    padding-right: 1rem;
+    background-image: none;
+}
+
+.custom-select:disabled, select:disabled {
+    color: #777677;
+    background-color: #e9ecef;
+}
+
+.custom-select::-ms-expand, select::-ms-expand {
+    display: none;
+}
+
+.custom-select-sm {
+    height: calc(1.5em + 0.5rem + 2px);
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    padding-left: 0.5rem;
+    font-size: 0.875rem;
+}
+
+.custom-select-lg, #google_translate_element select {
+    height: calc(1.5em + 1rem + 2px);
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 1rem;
+    font-size: 1.25rem;
+}
+
+.custom-file {
+    position: relative;
+    display: inline-block;
+    width: 100%;
+    height: calc(1.5em + 1rem + 2px);
+    margin-bottom: 0;
+}
+
+.custom-file-input {
+    position: relative;
+    z-index: 2;
+    width: 100%;
+    height: calc(1.5em + 1rem + 2px);
+    margin: 0;
+    opacity: 0;
+}
+
+.custom-file-input:focus ~ .custom-file-label {
+    border-color: #0029F7;
+    box-shadow: 0 0 0 2px rgba(0, 41, 247, 0.75);
+}
+
+.custom-file-input:disabled ~ .custom-file-label {
+    background-color: #e9ecef;
+}
+
+.custom-file-input:lang(en) ~ .custom-file-label::after {
+    content: "Browse";
+}
+
+.custom-file-input ~ .custom-file-label[data-browse]::after {
+    content: attr(data-browse);
+}
+
+.custom-file-label {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 1;
+    height: calc(1.5em + 1rem + 2px);
+    padding: 0.5rem 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    background-color: #fff;
+    border: 1px solid #777677;
+}
+
+.custom-file-label::after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 3;
+    display: block;
+    height: calc(1.5em + 1rem);
+    padding: 0.5rem 1rem;
+    line-height: 1.5;
+    color: #495057;
+    content: "Browse";
+    background-color: #e9ecef;
+    border-left: inherit;
+}
+
+.custom-range {
+    width: 100%;
+    height: calc(1rem + 0.3rem);
+    padding: 0;
+    background-color: transparent;
+    appearance: none;
+}
+
+.custom-range:focus {
+    outline: none;
+}
+
+.custom-range:focus::-webkit-slider-thumb {
+    box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 41, 247, 0.75);
+}
+
+.custom-range:focus::-moz-range-thumb {
+    box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 41, 247, 0.75);
+}
+
+.custom-range:focus::-ms-thumb {
+    box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 41, 247, 0.75);
+}
+
+.custom-range::-moz-focus-outer {
+    border: 0;
+}
+
+.custom-range::-webkit-slider-thumb {
+    width: 1rem;
+    height: 1rem;
+    margin-top: -0.25rem;
+    background-color: #A513B6;
+    border: 0;
+    transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    appearance: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .custom-range::-webkit-slider-thumb {
+        transition: none;
+    }
+}
+
+.custom-range::-webkit-slider-thumb:active {
+    background-color: #e889f3;
+}
+
+.custom-range::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 0.5rem;
+    color: transparent;
+    cursor: pointer;
+    background-color: #dee2e6;
+    border-color: transparent;
+}
+
+.custom-range::-moz-range-thumb {
+    width: 1rem;
+    height: 1rem;
+    background-color: #A513B6;
+    border: 0;
+    transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    appearance: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .custom-range::-moz-range-thumb {
+        transition: none;
+    }
+}
+
+.custom-range::-moz-range-thumb:active {
+    background-color: #e889f3;
+}
+
+.custom-range::-moz-range-track {
+    width: 100%;
+    height: 0.5rem;
+    color: transparent;
+    cursor: pointer;
+    background-color: #dee2e6;
+    border-color: transparent;
+}
+
+.custom-range::-ms-thumb {
+    width: 1rem;
+    height: 1rem;
+    margin-top: 0;
+    margin-right: 0.15rem;
+    margin-left: 0.15rem;
+    background-color: #A513B6;
+    border: 0;
+    transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    appearance: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .custom-range::-ms-thumb {
+        transition: none;
+    }
+}
+
+.custom-range::-ms-thumb:active {
+    background-color: #e889f3;
+}
+
+.custom-range::-ms-track {
+    width: 100%;
+    height: 0.5rem;
+    color: transparent;
+    cursor: pointer;
+    background-color: transparent;
+    border-color: transparent;
+    border-width: 0.5rem;
+}
+
+.custom-range::-ms-fill-lower {
+    background-color: #dee2e6;
+}
+
+.custom-range::-ms-fill-upper {
+    margin-right: 15px;
+    background-color: #dee2e6;
+}
+
+.custom-range:disabled::-webkit-slider-thumb {
+    background-color: #adb5bd;
+}
+
+.custom-range:disabled::-webkit-slider-runnable-track {
+    cursor: default;
+}
+
+.custom-range:disabled::-moz-range-thumb {
+    background-color: #adb5bd;
+}
+
+.custom-range:disabled::-moz-range-track {
+    cursor: default;
+}
+
+.custom-range:disabled::-ms-thumb {
+    background-color: #adb5bd;
+}
+
+.custom-control-label::before,
+.custom-file-label, .custom-select, select {
+    transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .custom-control-label::before,
+    .custom-file-label, .custom-select, select {
+        transition: none;
+    }
+}
+
+.nav {
+    display: flex;
+    flex-wrap: wrap;
+    padding-left: 0;
+    margin-bottom: 0;
+    list-style: none;
+}
+
+.nav-link {
+    display: block;
+    padding: 0.75rem 1rem;
+}
+
+.nav-link:hover, .nav-link:focus {
+    text-decoration: none;
+}
+
+.nav-link.disabled {
+    color: #777677;
+    pointer-events: none;
+    cursor: default;
+}
+
+.nav-tabs {
+    border-bottom: 1px solid #dee2e6;
+}
+
+.nav-tabs .nav-item {
+    margin-bottom: -1px;
+}
+
+.nav-tabs .nav-link {
+    border: 1px solid transparent;
+}
+
+.nav-tabs .nav-link:hover, .nav-tabs .nav-link:focus {
+    border-color: #e9ecef #e9ecef #dee2e6;
+}
+
+.nav-tabs .nav-link.disabled {
+    color: #777677;
+    background-color: transparent;
+    border-color: transparent;
+}
+
+.nav-tabs .nav-link.active,
+.nav-tabs .nav-item.show .nav-link {
+    color: #495057;
+    background-color: #fff;
+    border-color: #dee2e6 #dee2e6 #fff;
+}
+
+.nav-tabs .dropdown-menu {
+    margin-top: -1px;
+}
+
+.nav-pills .nav-link.active,
+.nav-pills .show > .nav-link {
+    color: #fff;
+    background-color: #A513B6;
+}
+
+.nav-fill .nav-item, #global-header .nav-pills .nav-item {
+    flex: 1 1 auto;
+    text-align: center;
+}
+
+.nav-justified .nav-item {
+    flex-basis: 0;
+    flex-grow: 1;
+    text-align: center;
+}
+
+.tab-content > .tab-pane {
+    display: none;
+}
+
+.tab-content > .active {
+    display: block;
+}
+
+.card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    word-wrap: break-word;
+    background-color: #fff;
+    background-clip: border-box;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.card > hr {
+    margin-right: 0;
+    margin-left: 0;
+}
+
+.card-body {
+    flex: 1 1 auto;
+    padding: 1rem;
+}
+
+.card-title {
+    margin-bottom: 1rem;
+}
+
+.card-subtitle {
+    margin-top: -0.5rem;
+    margin-bottom: 0;
+}
+
+.card-text:last-child {
+    margin-bottom: 0;
+}
+
+.card-link:hover {
+    text-decoration: none;
+}
+
+.card-link + .card-link {
+    margin-left: 1rem;
+}
+
+.card-header {
+    padding: 1rem 1rem;
+    margin-bottom: 0;
+    background-color: rgba(0, 0, 0, 0.05);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.card-header + .list-group .list-group-item:first-child {
+    border-top: 0;
+}
+
+.card-footer {
+    padding: 1rem 1rem;
+    background-color: rgba(0, 0, 0, 0.05);
+    border-top: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.card-header-tabs {
+    margin-right: -0.5rem;
+    margin-bottom: -1rem;
+    margin-left: -0.5rem;
+    border-bottom: 0;
+}
+
+.card-header-pills {
+    margin-right: -0.5rem;
+    margin-left: -0.5rem;
+}
+
+.card-img-overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    padding: 1.25rem;
+}
+
+.card-img {
+    width: 100%;
+}
+
+.card-img-top {
+    width: 100%;
+}
+
+.card-img-bottom {
+    width: 100%;
+}
+
+.card-deck {
+    display: flex;
+    flex-direction: column;
+}
+
+.card-deck .card {
+    margin-bottom: 1rem;
+}
+
+@media (min-width: 480px) {
+    .card-deck {
+        flex-flow: row wrap;
+        margin-right: -1rem;
+        margin-left: -1rem;
+    }
+    .card-deck .card {
+        display: flex;
+        flex: 1 0 0%;
+        flex-direction: column;
+        margin-right: 1rem;
+        margin-bottom: 0;
+        margin-left: 1rem;
+    }
+}
+
+.card-group {
+    display: flex;
+    flex-direction: column;
+}
+
+.card-group > .card {
+    margin-bottom: 1rem;
+}
+
+@media (min-width: 480px) {
+    .card-group {
+        flex-flow: row wrap;
+    }
+    .card-group > .card {
+        flex: 1 0 0%;
+        margin-bottom: 0;
+    }
+    .card-group > .card + .card {
+        margin-left: 0;
+        border-left: 0;
+    }
+}
+
+.card-columns .card {
+    margin-bottom: 1rem;
+}
+
+@media (min-width: 480px) {
+    .card-columns {
+        column-count: 3;
+        column-gap: 1.25rem;
+        orphans: 1;
+        widows: 1;
+    }
+    .card-columns .card {
+        display: inline-block;
+        width: 100%;
+    }
+}
+
+.accordion > .card {
+    overflow: hidden;
+}
+
+.accordion > .card:not(:first-of-type):not(:last-of-type) {
+    border-bottom: 0;
+}
+
+.accordion > .card:first-of-type {
+    border-bottom: 0;
+}
+
+.accordion > .card .card-header {
+    margin-bottom: -1px;
+}
+
+.alert {
+    position: relative;
+    padding: 1rem 1rem;
+    margin-bottom: 1rem;
+    border: 1px solid transparent;
+}
+
+.alert-heading {
+    color: inherit;
+}
+
+.alert-link {
+    font-weight: 700;
+}
+
+.alert-dismissible {
+    padding-right: 3.5rem;
+}
+
+.alert-dismissible .close {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 1rem 1rem;
+    color: inherit;
+}
+
+.alert-primary {
+    color: #0c0e40;
+    background-color: #d1d1e5;
+    border-color: #bebfda;
+}
+
+.alert-primary hr {
+    border-top-color: #aeafd1;
+}
+
+.alert-primary .alert-link {
+    color: #040515;
+}
+
+.alert-secondary {
+    color: #1f3880;
+    background-color: #d8e2fd;
+    border-color: #c8d6fc;
+}
+
+.alert-secondary hr {
+    border-top-color: #b0c4fb;
+}
+
+.alert-secondary .alert-link {
+    color: #152657;
+}
+
+.alert-success {
+    color: #114721;
+    background-color: #d3e7d9;
+    border-color: #c1dec9;
+}
+
+.alert-success hr {
+    border-top-color: #b0d5bb;
+}
+
+.alert-success .alert-link {
+    color: #071e0e;
+}
+
+.alert-info {
+    color: #560a5f;
+    background-color: #edd0f0;
+    border-color: #e6bdeb;
+}
+
+.alert-info hr {
+    border-top-color: #dfa9e5;
+}
+
+.alert-info .alert-link {
+    color: #2c0531;
+}
+
+.alert-warning {
+    color: #856404;
+    background-color: #fff3cd;
+    border-color: #ffeeba;
+}
+
+.alert-warning hr {
+    border-top-color: #ffe8a1;
+}
+
+.alert-warning .alert-link {
+    color: #533f03;
+}
+
+.alert-danger {
+    color: #7a0c16;
+    background-color: #fbd1d5;
+    border-color: #f9bec4;
+}
+
+.alert-danger hr {
+    border-top-color: #f7a7af;
+}
+
+.alert-danger .alert-link {
+    color: #4c070e;
+}
+
+.alert-light {
+    color: #787b80;
+    background-color: #fafbfd;
+    border-color: #f8fafd;
+}
+
+.alert-light hr {
+    border-top-color: #e4ecf7;
+}
+
+.alert-light .alert-link {
+    color: #5f6266;
+}
+
+.alert-dark {
+    color: #050a1d;
+    background-color: #ced0d7;
+    border-color: #babdc7;
+}
+
+.alert-dark hr {
+    border-top-color: #acb0bc;
+}
+
+.alert-dark .alert-link {
+    color: black;
+}
+
+.alert-white {
+    color: #858585;
+    background-color: white;
+    border-color: white;
+}
+
+.alert-white hr {
+    border-top-color: #f2f2f2;
+}
+
+.alert-white .alert-link {
+    color: #6c6c6c;
+}
+
+.alert-black {
+    color: black;
+    background-color: #cccccc;
+    border-color: #b8b8b8;
+}
+
+.alert-black hr {
+    border-top-color: #ababab;
+}
+
+.alert-black .alert-link {
+    color: black;
+}
+
+.media {
+    display: flex;
+    align-items: flex-start;
+}
+
+.media-body {
+    flex: 1;
+}
+
+.list-group {
+    display: flex;
+    flex-direction: column;
+    padding-left: 0;
+    margin-bottom: 0;
+}
+
+.list-group-item-action {
+    width: 100%;
+    color: #495057;
+    text-align: inherit;
+}
+
+.list-group-item-action:hover, .list-group-item-action:focus {
+    z-index: 1;
+    color: #495057;
+    text-decoration: none;
+    background-color: transparent;
+}
+
+.list-group-item-action:active {
+    color: #212529;
+    background-color: transparent;
+}
+
+.list-group-item {
+    position: relative;
+    display: block;
+    padding: 0.5rem 1rem;
+    margin-bottom: -1px;
+    background-color: #fff;
+    border: 1px solid #dee2e6;
+}
+
+.list-group-item:last-child {
+    margin-bottom: 0;
+}
+
+.list-group-item.disabled, .list-group-item:disabled {
+    color: #777677;
+    pointer-events: none;
+    background-color: #fff;
+}
+
+.list-group-item.active {
+    z-index: 2;
+    color: #fff;
+    background-color: #A513B6;
+    border-color: #A513B6;
+}
+
+.list-group-horizontal {
+    flex-direction: row;
+}
+
+.list-group-horizontal .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0;
+}
+
+.list-group-horizontal .list-group-item:last-child {
+    margin-right: 0;
+}
+
+@media (min-width: 480px) {
+    .list-group-horizontal-sm {
+        flex-direction: row;
+    }
+    .list-group-horizontal-sm .list-group-item {
+        margin-right: -1px;
+        margin-bottom: 0;
+    }
+    .list-group-horizontal-sm .list-group-item:last-child {
+        margin-right: 0;
+    }
+}
+
+@media (min-width: 720px) {
+    .list-group-horizontal-md {
+        flex-direction: row;
+    }
+    .list-group-horizontal-md .list-group-item {
+        margin-right: -1px;
+        margin-bottom: 0;
+    }
+    .list-group-horizontal-md .list-group-item:last-child {
+        margin-right: 0;
+    }
+}
+
+@media (min-width: 960px) {
+    .list-group-horizontal-lg {
+        flex-direction: row;
+    }
+    .list-group-horizontal-lg .list-group-item {
+        margin-right: -1px;
+        margin-bottom: 0;
+    }
+    .list-group-horizontal-lg .list-group-item:last-child {
+        margin-right: 0;
+    }
+}
+
+@media (min-width: 1200px) {
+    .list-group-horizontal-xl {
+        flex-direction: row;
+    }
+    .list-group-horizontal-xl .list-group-item {
+        margin-right: -1px;
+        margin-bottom: 0;
+    }
+    .list-group-horizontal-xl .list-group-item:last-child {
+        margin-right: 0;
+    }
+}
+
+@media (min-width: 1440px) {
+    .list-group-horizontal-xxl {
+        flex-direction: row;
+    }
+    .list-group-horizontal-xxl .list-group-item {
+        margin-right: -1px;
+        margin-bottom: 0;
+    }
+    .list-group-horizontal-xxl .list-group-item:last-child {
+        margin-right: 0;
+    }
+}
+
+.list-group-flush .list-group-item {
+    border-right: 0;
+    border-left: 0;
+}
+
+.list-group-flush .list-group-item:last-child {
+    margin-bottom: -1px;
+}
+
+.list-group-flush:first-child .list-group-item:first-child {
+    border-top: 0;
+}
+
+.list-group-flush:last-child .list-group-item:last-child {
+    margin-bottom: 0;
+    border-bottom: 0;
+}
+
+.list-group-item-primary {
+    color: #0c0e40;
+    background-color: #bebfda;
+}
+
+.list-group-item-primary.list-group-item-action:hover, .list-group-item-primary.list-group-item-action:focus {
+    color: #0c0e40;
+    background-color: #aeafd1;
+}
+
+.list-group-item-primary.list-group-item-action.active {
+    color: #fff;
+    background-color: #0c0e40;
+    border-color: #0c0e40;
+}
+
+.list-group-item-secondary {
+    color: #1f3880;
+    background-color: #c8d6fc;
+}
+
+.list-group-item-secondary.list-group-item-action:hover, .list-group-item-secondary.list-group-item-action:focus {
+    color: #1f3880;
+    background-color: #b0c4fb;
+}
+
+.list-group-item-secondary.list-group-item-action.active {
+    color: #fff;
+    background-color: #1f3880;
+    border-color: #1f3880;
+}
+
+.list-group-item-success {
+    color: #114721;
+    background-color: #c1dec9;
+}
+
+.list-group-item-success.list-group-item-action:hover, .list-group-item-success.list-group-item-action:focus {
+    color: #114721;
+    background-color: #b0d5bb;
+}
+
+.list-group-item-success.list-group-item-action.active {
+    color: #fff;
+    background-color: #114721;
+    border-color: #114721;
+}
+
+.list-group-item-info {
+    color: #560a5f;
+    background-color: #e6bdeb;
+}
+
+.list-group-item-info.list-group-item-action:hover, .list-group-item-info.list-group-item-action:focus {
+    color: #560a5f;
+    background-color: #dfa9e5;
+}
+
+.list-group-item-info.list-group-item-action.active {
+    color: #fff;
+    background-color: #560a5f;
+    border-color: #560a5f;
+}
+
+.list-group-item-warning {
+    color: #856404;
+    background-color: #ffeeba;
+}
+
+.list-group-item-warning.list-group-item-action:hover, .list-group-item-warning.list-group-item-action:focus {
+    color: #856404;
+    background-color: #ffe8a1;
+}
+
+.list-group-item-warning.list-group-item-action.active {
+    color: #fff;
+    background-color: #856404;
+    border-color: #856404;
+}
+
+.list-group-item-danger {
+    color: #7a0c16;
+    background-color: #f9bec4;
+}
+
+.list-group-item-danger.list-group-item-action:hover, .list-group-item-danger.list-group-item-action:focus {
+    color: #7a0c16;
+    background-color: #f7a7af;
+}
+
+.list-group-item-danger.list-group-item-action.active {
+    color: #fff;
+    background-color: #7a0c16;
+    border-color: #7a0c16;
+}
+
+.list-group-item-light {
+    color: #787b80;
+    background-color: #f8fafd;
+}
+
+.list-group-item-light.list-group-item-action:hover, .list-group-item-light.list-group-item-action:focus {
+    color: #787b80;
+    background-color: #e4ecf7;
+}
+
+.list-group-item-light.list-group-item-action.active {
+    color: #fff;
+    background-color: #787b80;
+    border-color: #787b80;
+}
+
+.list-group-item-dark {
+    color: #050a1d;
+    background-color: #babdc7;
+}
+
+.list-group-item-dark.list-group-item-action:hover, .list-group-item-dark.list-group-item-action:focus {
+    color: #050a1d;
+    background-color: #acb0bc;
+}
+
+.list-group-item-dark.list-group-item-action.active {
+    color: #fff;
+    background-color: #050a1d;
+    border-color: #050a1d;
+}
+
+.list-group-item-white {
+    color: #858585;
+    background-color: white;
+}
+
+.list-group-item-white.list-group-item-action:hover, .list-group-item-white.list-group-item-action:focus {
+    color: #858585;
+    background-color: #f2f2f2;
+}
+
+.list-group-item-white.list-group-item-action.active {
+    color: #fff;
+    background-color: #858585;
+    border-color: #858585;
+}
+
+.list-group-item-black {
+    color: black;
+    background-color: #b8b8b8;
+}
+
+.list-group-item-black.list-group-item-action:hover, .list-group-item-black.list-group-item-action:focus {
+    color: black;
+    background-color: #ababab;
+}
+
+.list-group-item-black.list-group-item-action.active {
+    color: #fff;
+    background-color: black;
+    border-color: black;
+}
+
+.modal-open {
+    overflow: hidden;
+}
+
+.modal-open .modal {
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1050;
+    display: none;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    outline: 0;
+}
+
+.modal-dialog {
+    position: relative;
+    width: auto;
+    margin: 0.5rem;
+    pointer-events: none;
+}
+
+.modal.fade .modal-dialog {
+    transition: transform 0.3s ease-out;
+    transform: translate(0, -50px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .modal.fade .modal-dialog {
+        transition: none;
+    }
+}
+
+.modal.show .modal-dialog {
+    transform: none;
+}
+
+.modal-dialog-scrollable {
+    display: flex;
+    max-height: calc(100% - 1rem);
+}
+
+.modal-dialog-scrollable .modal-content {
+    max-height: calc(100vh - 1rem);
+    overflow: hidden;
+}
+
+.modal-dialog-scrollable .modal-header,
+.modal-dialog-scrollable .modal-footer {
+    flex-shrink: 0;
+}
+
+.modal-dialog-scrollable .modal-body {
+    overflow-y: auto;
+}
+
+.modal-dialog-centered {
+    display: flex;
+    align-items: center;
+    min-height: calc(100% - 1rem);
+}
+
+.modal-dialog-centered::before {
+    display: block;
+    height: calc(100vh - 1rem);
+    content: "";
+}
+
+.modal-dialog-centered.modal-dialog-scrollable {
+    flex-direction: column;
+    justify-content: center;
+    height: 100%;
+}
+
+.modal-dialog-centered.modal-dialog-scrollable .modal-content {
+    max-height: none;
+}
+
+.modal-dialog-centered.modal-dialog-scrollable::before {
+    content: none;
+}
+
+.modal-content {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    pointer-events: auto;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    outline: 0;
+}
+
+.modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1040;
+    width: 100vw;
+    height: 100vh;
+    background-color: #fff;
+}
+
+.modal-backdrop.fade {
+    opacity: 0;
+}
+
+.modal-backdrop.show {
+    opacity: 0.95;
+}
+
+.modal-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 1rem 1rem;
+    border-bottom: 1px solid #dee2e6;
+}
+
+.modal-header .close {
+    padding: 1rem 1rem;
+    margin: -1rem -1rem -1rem auto;
+}
+
+.modal-title {
+    margin-bottom: 0;
+    line-height: 1.5;
+}
+
+.modal-body {
+    position: relative;
+    flex: 1 1 auto;
+    padding: 1rem;
+}
+
+.modal-footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 1rem;
+    border-top: 1px solid #dee2e6;
+}
+
+.modal-footer > :not(:first-child) {
+    margin-left: .25rem;
+}
+
+.modal-footer > :not(:last-child) {
+    margin-right: .25rem;
+}
+
+.modal-scrollbar-measure {
+    position: absolute;
+    top: -9999px;
+    width: 50px;
+    height: 50px;
+    overflow: scroll;
+}
+
+@media (min-width: 480px) {
+    .modal-dialog {
+        max-width: 500px;
+        margin: 1.75rem auto;
+    }
+    .modal-dialog-scrollable {
+        max-height: calc(100% - 3.5rem);
+    }
+    .modal-dialog-scrollable .modal-content {
+        max-height: calc(100vh - 3.5rem);
+    }
+    .modal-dialog-centered {
+        min-height: calc(100% - 3.5rem);
+    }
+    .modal-dialog-centered::before {
+        height: calc(100vh - 3.5rem);
+    }
+    .modal-sm {
+        max-width: 300px;
+    }
+}
+
+@media (min-width: 960px) {
+    .modal-lg,
+    .modal-xl {
+        max-width: 800px;
+    }
+}
+
+@media (min-width: 1200px) {
+    .modal-xl {
+        max-width: 1140px;
+    }
+}
+
+.align-baseline {
+    vertical-align: baseline !important;
+}
+
+.align-top {
+    vertical-align: top !important;
+}
+
+.align-middle {
+    vertical-align: middle !important;
+}
+
+.align-bottom {
+    vertical-align: bottom !important;
+}
+
+.align-text-bottom {
+    vertical-align: text-bottom !important;
+}
+
+.align-text-top {
+    vertical-align: text-top !important;
+}
+
+.bg-primary {
+    background-color: #181A7B !important;
+}
+
+a.bg-primary:hover, a.bg-primary:focus,
+button.bg-primary:hover,
+button.bg-primary:focus {
+    background-color: #101150 !important;
+}
+
+.bg-secondary {
+    background-color: #3B6CF6 !important;
+}
+
+a.bg-secondary:hover, a.bg-secondary:focus,
+button.bg-secondary:hover,
+button.bg-secondary:focus {
+    background-color: #0b48f3 !important;
+}
+
+.bg-success {
+    background-color: #21883f !important;
+}
+
+a.bg-success:hover, a.bg-success:focus,
+button.bg-success:hover,
+button.bg-success:focus {
+    background-color: #175f2c !important;
+}
+
+.bg-info {
+    background-color: #A513B6 !important;
+}
+
+a.bg-info:hover, a.bg-info:focus,
+button.bg-info:hover,
+button.bg-info:focus {
+    background-color: #7b0e88 !important;
+}
+
+.bg-warning {
+    background-color: #ffc107 !important;
+}
+
+a.bg-warning:hover, a.bg-warning:focus,
+button.bg-warning:hover,
+button.bg-warning:focus {
+    background-color: #d39e00 !important;
+}
+
+.bg-danger {
+    background-color: #ea172b !important;
+}
+
+a.bg-danger:hover, a.bg-danger:focus,
+button.bg-danger:hover,
+button.bg-danger:focus {
+    background-color: #bd1121 !important;
+}
+
+.bg-light {
+    background-color: #e6ecf7 !important;
+}
+
+a.bg-light:hover, a.bg-light:focus,
+button.bg-light:hover,
+button.bg-light:focus {
+    background-color: #bfcfeb !important;
+}
+
+.bg-dark {
+    background-color: #0A1438 !important;
+}
+
+a.bg-dark:hover, a.bg-dark:focus,
+button.bg-dark:hover,
+button.bg-dark:focus {
+    background-color: #02050d !important;
+}
+
+.bg-white {
+    background-color: #fff !important;
+}
+
+a.bg-white:hover, a.bg-white:focus,
+button.bg-white:hover,
+button.bg-white:focus {
+    background-color: #e6e6e6 !important;
+}
+
+.bg-black {
+    background-color: #000 !important;
+}
+
+a.bg-black:hover, a.bg-black:focus,
+button.bg-black:hover,
+button.bg-black:focus {
+    background-color: black !important;
+}
+
+.bg-white {
+    background-color: #fff !important;
+}
+
+.bg-transparent {
+    background-color: transparent !important;
+}
+
+.border {
+    border: 1px solid #dee2e6 !important;
+}
+
+.border-top {
+    border-top: 1px solid #dee2e6 !important;
+}
+
+.border-right {
+    border-right: 1px solid #dee2e6 !important;
+}
+
+.border-bottom {
+    border-bottom: 1px solid #dee2e6 !important;
+}
+
+.border-left {
+    border-left: 1px solid #dee2e6 !important;
+}
+
+.border-0 {
+    border: 0 !important;
+}
+
+.border-top-0 {
+    border-top: 0 !important;
+}
+
+.border-right-0 {
+    border-right: 0 !important;
+}
+
+.border-bottom-0, thead th {
+    border-bottom: 0 !important;
+}
+
+.border-left-0 {
+    border-left: 0 !important;
+}
+
+.border-primary {
+    border-color: #181A7B !important;
+}
+
+.border-secondary {
+    border-color: #3B6CF6 !important;
+}
+
+.border-success {
+    border-color: #21883f !important;
+}
+
+.border-info {
+    border-color: #A513B6 !important;
+}
+
+.border-warning {
+    border-color: #ffc107 !important;
+}
+
+.border-danger {
+    border-color: #ea172b !important;
+}
+
+.border-light {
+    border-color: #e6ecf7 !important;
+}
+
+.border-dark {
+    border-color: #0A1438 !important;
+}
+
+.border-white {
+    border-color: #fff !important;
+}
+
+.border-black {
+    border-color: #000 !important;
+}
+
+.border-white {
+    border-color: #fff !important;
+}
+
+.rounded-sm {
+    border-radius: 0.25rem !important;
+}
+
+.rounded {
+    border-radius: 0.5rem !important;
+}
+
+.rounded-top {
+    border-top-left-radius: 0.5rem !important;
+    border-top-right-radius: 0.5rem !important;
+}
+
+.rounded-right {
+    border-top-right-radius: 0.5rem !important;
+    border-bottom-right-radius: 0.5rem !important;
+}
+
+.rounded-bottom {
+    border-bottom-right-radius: 0.5rem !important;
+    border-bottom-left-radius: 0.5rem !important;
+}
+
+.rounded-left {
+    border-top-left-radius: 0.5rem !important;
+    border-bottom-left-radius: 0.5rem !important;
+}
+
+.rounded-lg {
+    border-radius: 1rem !important;
+}
+
+.rounded-circle {
+    border-radius: 50% !important;
+}
+
+.rounded-pill {
+    border-radius: 50rem !important;
+}
+
+.rounded-0 {
+    border-radius: 0 !important;
+}
+
+.clearfix::after, fieldset::after {
+    display: block;
+    clear: both;
+    content: "";
+}
+
+.d-none {
+    display: none !important;
+}
+
+.d-inline {
+    display: inline !important;
+}
+
+.d-inline-block {
+    display: inline-block !important;
+}
+
+.d-block {
+    display: block !important;
+}
+
+.d-table {
+    display: table !important;
+}
+
+.d-table-row {
+    display: table-row !important;
+}
+
+.d-table-cell {
+    display: table-cell !important;
+}
+
+.d-flex {
+    display: flex !important;
+}
+
+.d-inline-flex {
+    display: inline-flex !important;
+}
+
+@media (min-width: 480px) {
+    .d-sm-none {
+        display: none !important;
+    }
+    .d-sm-inline {
+        display: inline !important;
+    }
+    .d-sm-inline-block {
+        display: inline-block !important;
+    }
+    .d-sm-block {
+        display: block !important;
+    }
+    .d-sm-table {
+        display: table !important;
+    }
+    .d-sm-table-row {
+        display: table-row !important;
+    }
+    .d-sm-table-cell {
+        display: table-cell !important;
+    }
+    .d-sm-flex {
+        display: flex !important;
+    }
+    .d-sm-inline-flex {
+        display: inline-flex !important;
+    }
+}
+
+@media (min-width: 720px) {
+    .d-md-none {
+        display: none !important;
+    }
+    .d-md-inline {
+        display: inline !important;
+    }
+    .d-md-inline-block {
+        display: inline-block !important;
+    }
+    .d-md-block {
+        display: block !important;
+    }
+    .d-md-table {
+        display: table !important;
+    }
+    .d-md-table-row {
+        display: table-row !important;
+    }
+    .d-md-table-cell {
+        display: table-cell !important;
+    }
+    .d-md-flex {
+        display: flex !important;
+    }
+    .d-md-inline-flex {
+        display: inline-flex !important;
+    }
+}
+
+@media (min-width: 960px) {
+    .d-lg-none {
+        display: none !important;
+    }
+    .d-lg-inline {
+        display: inline !important;
+    }
+    .d-lg-inline-block {
+        display: inline-block !important;
+    }
+    .d-lg-block {
+        display: block !important;
+    }
+    .d-lg-table {
+        display: table !important;
+    }
+    .d-lg-table-row {
+        display: table-row !important;
+    }
+    .d-lg-table-cell {
+        display: table-cell !important;
+    }
+    .d-lg-flex {
+        display: flex !important;
+    }
+    .d-lg-inline-flex {
+        display: inline-flex !important;
+    }
+}
+
+@media (min-width: 1200px) {
+    .d-xl-none {
+        display: none !important;
+    }
+    .d-xl-inline {
+        display: inline !important;
+    }
+    .d-xl-inline-block {
+        display: inline-block !important;
+    }
+    .d-xl-block {
+        display: block !important;
+    }
+    .d-xl-table {
+        display: table !important;
+    }
+    .d-xl-table-row {
+        display: table-row !important;
+    }
+    .d-xl-table-cell {
+        display: table-cell !important;
+    }
+    .d-xl-flex {
+        display: flex !important;
+    }
+    .d-xl-inline-flex {
+        display: inline-flex !important;
+    }
+}
+
+@media (min-width: 1440px) {
+    .d-xxl-none {
+        display: none !important;
+    }
+    .d-xxl-inline {
+        display: inline !important;
+    }
+    .d-xxl-inline-block {
+        display: inline-block !important;
+    }
+    .d-xxl-block {
+        display: block !important;
+    }
+    .d-xxl-table {
+        display: table !important;
+    }
+    .d-xxl-table-row {
+        display: table-row !important;
+    }
+    .d-xxl-table-cell {
+        display: table-cell !important;
+    }
+    .d-xxl-flex {
+        display: flex !important;
+    }
+    .d-xxl-inline-flex {
+        display: inline-flex !important;
+    }
+}
+
+@media print {
+    .d-print-none {
+        display: none !important;
+    }
+    .d-print-inline {
+        display: inline !important;
+    }
+    .d-print-inline-block {
+        display: inline-block !important;
+    }
+    .d-print-block {
+        display: block !important;
+    }
+    .d-print-table {
+        display: table !important;
+    }
+    .d-print-table-row {
+        display: table-row !important;
+    }
+    .d-print-table-cell {
+        display: table-cell !important;
+    }
+    .d-print-flex {
+        display: flex !important;
+    }
+    .d-print-inline-flex {
+        display: inline-flex !important;
+    }
+}
+
+.embed-responsive {
+    position: relative;
+    display: block;
+    width: 100%;
+    padding: 0;
+    overflow: hidden;
+}
+
+.embed-responsive::before {
+    display: block;
+    content: "";
+}
+
+.embed-responsive .embed-responsive-item,
+.embed-responsive iframe,
+.embed-responsive embed,
+.embed-responsive object,
+.embed-responsive video {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
+.embed-responsive-21by9::before {
+    padding-top: 42.8571428571%;
+}
+
+.embed-responsive-16by9::before {
+    padding-top: 56.25%;
+}
+
+.embed-responsive-4by3::before {
+    padding-top: 75%;
+}
+
+.embed-responsive-1by1::before {
+    padding-top: 100%;
+}
+
+.flex-row {
+    flex-direction: row !important;
+}
+
+.flex-column {
+    flex-direction: column !important;
+}
+
+.flex-row-reverse {
+    flex-direction: row-reverse !important;
+}
+
+.flex-column-reverse {
+    flex-direction: column-reverse !important;
+}
+
+.flex-wrap {
+    flex-wrap: wrap !important;
+}
+
+.flex-nowrap {
+    flex-wrap: nowrap !important;
+}
+
+.flex-wrap-reverse {
+    flex-wrap: wrap-reverse !important;
+}
+
+.flex-fill {
+    flex: 1 1 auto !important;
+}
+
+.flex-grow-0 {
+    flex-grow: 0 !important;
+}
+
+.flex-grow-1 {
+    flex-grow: 1 !important;
+}
+
+.flex-shrink-0 {
+    flex-shrink: 0 !important;
+}
+
+.flex-shrink-1 {
+    flex-shrink: 1 !important;
+}
+
+.justify-content-start {
+    justify-content: flex-start !important;
+}
+
+.justify-content-end {
+    justify-content: flex-end !important;
+}
+
+.justify-content-center {
+    justify-content: center !important;
+}
+
+.justify-content-between {
+    justify-content: space-between !important;
+}
+
+.justify-content-around {
+    justify-content: space-around !important;
+}
+
+.align-items-start {
+    align-items: flex-start !important;
+}
+
+.align-items-end {
+    align-items: flex-end !important;
+}
+
+.align-items-center {
+    align-items: center !important;
+}
+
+.align-items-baseline {
+    align-items: baseline !important;
+}
+
+.align-items-stretch {
+    align-items: stretch !important;
+}
+
+.align-content-start {
+    align-content: flex-start !important;
+}
+
+.align-content-end {
+    align-content: flex-end !important;
+}
+
+.align-content-center {
+    align-content: center !important;
+}
+
+.align-content-between {
+    align-content: space-between !important;
+}
+
+.align-content-around {
+    align-content: space-around !important;
+}
+
+.align-content-stretch {
+    align-content: stretch !important;
+}
+
+.align-self-auto {
+    align-self: auto !important;
+}
+
+.align-self-start {
+    align-self: flex-start !important;
+}
+
+.align-self-end {
+    align-self: flex-end !important;
+}
+
+.align-self-center {
+    align-self: center !important;
+}
+
+.align-self-baseline {
+    align-self: baseline !important;
+}
+
+.align-self-stretch {
+    align-self: stretch !important;
+}
+
+@media (min-width: 480px) {
+    .flex-sm-row {
+        flex-direction: row !important;
+    }
+    .flex-sm-column {
+        flex-direction: column !important;
+    }
+    .flex-sm-row-reverse {
+        flex-direction: row-reverse !important;
+    }
+    .flex-sm-column-reverse {
+        flex-direction: column-reverse !important;
+    }
+    .flex-sm-wrap {
+        flex-wrap: wrap !important;
+    }
+    .flex-sm-nowrap {
+        flex-wrap: nowrap !important;
+    }
+    .flex-sm-wrap-reverse {
+        flex-wrap: wrap-reverse !important;
+    }
+    .flex-sm-fill {
+        flex: 1 1 auto !important;
+    }
+    .flex-sm-grow-0 {
+        flex-grow: 0 !important;
+    }
+    .flex-sm-grow-1 {
+        flex-grow: 1 !important;
+    }
+    .flex-sm-shrink-0 {
+        flex-shrink: 0 !important;
+    }
+    .flex-sm-shrink-1 {
+        flex-shrink: 1 !important;
+    }
+    .justify-content-sm-start {
+        justify-content: flex-start !important;
+    }
+    .justify-content-sm-end {
+        justify-content: flex-end !important;
+    }
+    .justify-content-sm-center {
+        justify-content: center !important;
+    }
+    .justify-content-sm-between {
+        justify-content: space-between !important;
+    }
+    .justify-content-sm-around {
+        justify-content: space-around !important;
+    }
+    .align-items-sm-start {
+        align-items: flex-start !important;
+    }
+    .align-items-sm-end {
+        align-items: flex-end !important;
+    }
+    .align-items-sm-center {
+        align-items: center !important;
+    }
+    .align-items-sm-baseline {
+        align-items: baseline !important;
+    }
+    .align-items-sm-stretch {
+        align-items: stretch !important;
+    }
+    .align-content-sm-start {
+        align-content: flex-start !important;
+    }
+    .align-content-sm-end {
+        align-content: flex-end !important;
+    }
+    .align-content-sm-center {
+        align-content: center !important;
+    }
+    .align-content-sm-between {
+        align-content: space-between !important;
+    }
+    .align-content-sm-around {
+        align-content: space-around !important;
+    }
+    .align-content-sm-stretch {
+        align-content: stretch !important;
+    }
+    .align-self-sm-auto {
+        align-self: auto !important;
+    }
+    .align-self-sm-start {
+        align-self: flex-start !important;
+    }
+    .align-self-sm-end {
+        align-self: flex-end !important;
+    }
+    .align-self-sm-center {
+        align-self: center !important;
+    }
+    .align-self-sm-baseline {
+        align-self: baseline !important;
+    }
+    .align-self-sm-stretch {
+        align-self: stretch !important;
+    }
+}
+
+@media (min-width: 720px) {
+    .flex-md-row {
+        flex-direction: row !important;
+    }
+    .flex-md-column {
+        flex-direction: column !important;
+    }
+    .flex-md-row-reverse {
+        flex-direction: row-reverse !important;
+    }
+    .flex-md-column-reverse {
+        flex-direction: column-reverse !important;
+    }
+    .flex-md-wrap {
+        flex-wrap: wrap !important;
+    }
+    .flex-md-nowrap {
+        flex-wrap: nowrap !important;
+    }
+    .flex-md-wrap-reverse {
+        flex-wrap: wrap-reverse !important;
+    }
+    .flex-md-fill {
+        flex: 1 1 auto !important;
+    }
+    .flex-md-grow-0 {
+        flex-grow: 0 !important;
+    }
+    .flex-md-grow-1 {
+        flex-grow: 1 !important;
+    }
+    .flex-md-shrink-0 {
+        flex-shrink: 0 !important;
+    }
+    .flex-md-shrink-1 {
+        flex-shrink: 1 !important;
+    }
+    .justify-content-md-start {
+        justify-content: flex-start !important;
+    }
+    .justify-content-md-end {
+        justify-content: flex-end !important;
+    }
+    .justify-content-md-center {
+        justify-content: center !important;
+    }
+    .justify-content-md-between {
+        justify-content: space-between !important;
+    }
+    .justify-content-md-around {
+        justify-content: space-around !important;
+    }
+    .align-items-md-start {
+        align-items: flex-start !important;
+    }
+    .align-items-md-end {
+        align-items: flex-end !important;
+    }
+    .align-items-md-center {
+        align-items: center !important;
+    }
+    .align-items-md-baseline {
+        align-items: baseline !important;
+    }
+    .align-items-md-stretch {
+        align-items: stretch !important;
+    }
+    .align-content-md-start {
+        align-content: flex-start !important;
+    }
+    .align-content-md-end {
+        align-content: flex-end !important;
+    }
+    .align-content-md-center {
+        align-content: center !important;
+    }
+    .align-content-md-between {
+        align-content: space-between !important;
+    }
+    .align-content-md-around {
+        align-content: space-around !important;
+    }
+    .align-content-md-stretch {
+        align-content: stretch !important;
+    }
+    .align-self-md-auto {
+        align-self: auto !important;
+    }
+    .align-self-md-start {
+        align-self: flex-start !important;
+    }
+    .align-self-md-end {
+        align-self: flex-end !important;
+    }
+    .align-self-md-center {
+        align-self: center !important;
+    }
+    .align-self-md-baseline {
+        align-self: baseline !important;
+    }
+    .align-self-md-stretch {
+        align-self: stretch !important;
+    }
+}
+
+@media (min-width: 960px) {
+    .flex-lg-row {
+        flex-direction: row !important;
+    }
+    .flex-lg-column {
+        flex-direction: column !important;
+    }
+    .flex-lg-row-reverse {
+        flex-direction: row-reverse !important;
+    }
+    .flex-lg-column-reverse {
+        flex-direction: column-reverse !important;
+    }
+    .flex-lg-wrap {
+        flex-wrap: wrap !important;
+    }
+    .flex-lg-nowrap {
+        flex-wrap: nowrap !important;
+    }
+    .flex-lg-wrap-reverse {
+        flex-wrap: wrap-reverse !important;
+    }
+    .flex-lg-fill {
+        flex: 1 1 auto !important;
+    }
+    .flex-lg-grow-0 {
+        flex-grow: 0 !important;
+    }
+    .flex-lg-grow-1 {
+        flex-grow: 1 !important;
+    }
+    .flex-lg-shrink-0 {
+        flex-shrink: 0 !important;
+    }
+    .flex-lg-shrink-1 {
+        flex-shrink: 1 !important;
+    }
+    .justify-content-lg-start {
+        justify-content: flex-start !important;
+    }
+    .justify-content-lg-end {
+        justify-content: flex-end !important;
+    }
+    .justify-content-lg-center {
+        justify-content: center !important;
+    }
+    .justify-content-lg-between {
+        justify-content: space-between !important;
+    }
+    .justify-content-lg-around {
+        justify-content: space-around !important;
+    }
+    .align-items-lg-start {
+        align-items: flex-start !important;
+    }
+    .align-items-lg-end {
+        align-items: flex-end !important;
+    }
+    .align-items-lg-center {
+        align-items: center !important;
+    }
+    .align-items-lg-baseline {
+        align-items: baseline !important;
+    }
+    .align-items-lg-stretch {
+        align-items: stretch !important;
+    }
+    .align-content-lg-start {
+        align-content: flex-start !important;
+    }
+    .align-content-lg-end {
+        align-content: flex-end !important;
+    }
+    .align-content-lg-center {
+        align-content: center !important;
+    }
+    .align-content-lg-between {
+        align-content: space-between !important;
+    }
+    .align-content-lg-around {
+        align-content: space-around !important;
+    }
+    .align-content-lg-stretch {
+        align-content: stretch !important;
+    }
+    .align-self-lg-auto {
+        align-self: auto !important;
+    }
+    .align-self-lg-start {
+        align-self: flex-start !important;
+    }
+    .align-self-lg-end {
+        align-self: flex-end !important;
+    }
+    .align-self-lg-center {
+        align-self: center !important;
+    }
+    .align-self-lg-baseline {
+        align-self: baseline !important;
+    }
+    .align-self-lg-stretch {
+        align-self: stretch !important;
+    }
+}
+
+@media (min-width: 1200px) {
+    .flex-xl-row {
+        flex-direction: row !important;
+    }
+    .flex-xl-column {
+        flex-direction: column !important;
+    }
+    .flex-xl-row-reverse {
+        flex-direction: row-reverse !important;
+    }
+    .flex-xl-column-reverse {
+        flex-direction: column-reverse !important;
+    }
+    .flex-xl-wrap {
+        flex-wrap: wrap !important;
+    }
+    .flex-xl-nowrap {
+        flex-wrap: nowrap !important;
+    }
+    .flex-xl-wrap-reverse {
+        flex-wrap: wrap-reverse !important;
+    }
+    .flex-xl-fill {
+        flex: 1 1 auto !important;
+    }
+    .flex-xl-grow-0 {
+        flex-grow: 0 !important;
+    }
+    .flex-xl-grow-1 {
+        flex-grow: 1 !important;
+    }
+    .flex-xl-shrink-0 {
+        flex-shrink: 0 !important;
+    }
+    .flex-xl-shrink-1 {
+        flex-shrink: 1 !important;
+    }
+    .justify-content-xl-start {
+        justify-content: flex-start !important;
+    }
+    .justify-content-xl-end {
+        justify-content: flex-end !important;
+    }
+    .justify-content-xl-center {
+        justify-content: center !important;
+    }
+    .justify-content-xl-between {
+        justify-content: space-between !important;
+    }
+    .justify-content-xl-around {
+        justify-content: space-around !important;
+    }
+    .align-items-xl-start {
+        align-items: flex-start !important;
+    }
+    .align-items-xl-end {
+        align-items: flex-end !important;
+    }
+    .align-items-xl-center {
+        align-items: center !important;
+    }
+    .align-items-xl-baseline {
+        align-items: baseline !important;
+    }
+    .align-items-xl-stretch {
+        align-items: stretch !important;
+    }
+    .align-content-xl-start {
+        align-content: flex-start !important;
+    }
+    .align-content-xl-end {
+        align-content: flex-end !important;
+    }
+    .align-content-xl-center {
+        align-content: center !important;
+    }
+    .align-content-xl-between {
+        align-content: space-between !important;
+    }
+    .align-content-xl-around {
+        align-content: space-around !important;
+    }
+    .align-content-xl-stretch {
+        align-content: stretch !important;
+    }
+    .align-self-xl-auto {
+        align-self: auto !important;
+    }
+    .align-self-xl-start {
+        align-self: flex-start !important;
+    }
+    .align-self-xl-end {
+        align-self: flex-end !important;
+    }
+    .align-self-xl-center {
+        align-self: center !important;
+    }
+    .align-self-xl-baseline {
+        align-self: baseline !important;
+    }
+    .align-self-xl-stretch {
+        align-self: stretch !important;
+    }
+}
+
+@media (min-width: 1440px) {
+    .flex-xxl-row {
+        flex-direction: row !important;
+    }
+    .flex-xxl-column {
+        flex-direction: column !important;
+    }
+    .flex-xxl-row-reverse {
+        flex-direction: row-reverse !important;
+    }
+    .flex-xxl-column-reverse {
+        flex-direction: column-reverse !important;
+    }
+    .flex-xxl-wrap {
+        flex-wrap: wrap !important;
+    }
+    .flex-xxl-nowrap {
+        flex-wrap: nowrap !important;
+    }
+    .flex-xxl-wrap-reverse {
+        flex-wrap: wrap-reverse !important;
+    }
+    .flex-xxl-fill {
+        flex: 1 1 auto !important;
+    }
+    .flex-xxl-grow-0 {
+        flex-grow: 0 !important;
+    }
+    .flex-xxl-grow-1 {
+        flex-grow: 1 !important;
+    }
+    .flex-xxl-shrink-0 {
+        flex-shrink: 0 !important;
+    }
+    .flex-xxl-shrink-1 {
+        flex-shrink: 1 !important;
+    }
+    .justify-content-xxl-start {
+        justify-content: flex-start !important;
+    }
+    .justify-content-xxl-end {
+        justify-content: flex-end !important;
+    }
+    .justify-content-xxl-center {
+        justify-content: center !important;
+    }
+    .justify-content-xxl-between {
+        justify-content: space-between !important;
+    }
+    .justify-content-xxl-around {
+        justify-content: space-around !important;
+    }
+    .align-items-xxl-start {
+        align-items: flex-start !important;
+    }
+    .align-items-xxl-end {
+        align-items: flex-end !important;
+    }
+    .align-items-xxl-center {
+        align-items: center !important;
+    }
+    .align-items-xxl-baseline {
+        align-items: baseline !important;
+    }
+    .align-items-xxl-stretch {
+        align-items: stretch !important;
+    }
+    .align-content-xxl-start {
+        align-content: flex-start !important;
+    }
+    .align-content-xxl-end {
+        align-content: flex-end !important;
+    }
+    .align-content-xxl-center {
+        align-content: center !important;
+    }
+    .align-content-xxl-between {
+        align-content: space-between !important;
+    }
+    .align-content-xxl-around {
+        align-content: space-around !important;
+    }
+    .align-content-xxl-stretch {
+        align-content: stretch !important;
+    }
+    .align-self-xxl-auto {
+        align-self: auto !important;
+    }
+    .align-self-xxl-start {
+        align-self: flex-start !important;
+    }
+    .align-self-xxl-end {
+        align-self: flex-end !important;
+    }
+    .align-self-xxl-center {
+        align-self: center !important;
+    }
+    .align-self-xxl-baseline {
+        align-self: baseline !important;
+    }
+    .align-self-xxl-stretch {
+        align-self: stretch !important;
+    }
+}
+
+.float-left {
+    float: left !important;
+}
+
+.float-right {
+    float: right !important;
+}
+
+.float-none {
+    float: none !important;
+}
+
+@media (min-width: 480px) {
+    .float-sm-left {
+        float: left !important;
+    }
+    .float-sm-right {
+        float: right !important;
+    }
+    .float-sm-none {
+        float: none !important;
+    }
+}
+
+@media (min-width: 720px) {
+    .float-md-left {
+        float: left !important;
+    }
+    .float-md-right {
+        float: right !important;
+    }
+    .float-md-none {
+        float: none !important;
+    }
+}
+
+@media (min-width: 960px) {
+    .float-lg-left {
+        float: left !important;
+    }
+    .float-lg-right {
+        float: right !important;
+    }
+    .float-lg-none {
+        float: none !important;
+    }
+}
+
+@media (min-width: 1200px) {
+    .float-xl-left {
+        float: left !important;
+    }
+    .float-xl-right {
+        float: right !important;
+    }
+    .float-xl-none {
+        float: none !important;
+    }
+}
+
+@media (min-width: 1440px) {
+    .float-xxl-left {
+        float: left !important;
+    }
+    .float-xxl-right {
+        float: right !important;
+    }
+    .float-xxl-none {
+        float: none !important;
+    }
+}
+
+.overflow-auto {
+    overflow: auto !important;
+}
+
+.overflow-hidden {
+    overflow: hidden !important;
+}
+
+.position-static {
+    position: static !important;
+}
+
+.position-relative {
+    position: relative !important;
+}
+
+.position-absolute, .skip-menu {
+    position: absolute !important;
+}
+
+.position-fixed {
+    position: fixed !important;
+}
+
+.position-sticky {
+    position: sticky !important;
+}
+
+.fixed-top {
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 1030;
+}
+
+.fixed-bottom {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1030;
+}
+
+@supports (position: sticky) {
+    .sticky-top {
+        position: sticky;
+        top: 0;
+        z-index: 1020;
+    }
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.sr-only-focusable:active, .sr-only-focusable:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+}
+
+.shadow-sm {
+    box-shadow: 0 0 0.5rem rgba(10, 20, 56, 0.3) !important;
+}
+
+.shadow, #global-header .nav:not(.nav-pills) .dropdown-menu, .skip-menu {
+    box-shadow: 0 0 1rem rgba(10, 20, 56, 0.3) !important;
+}
+
+.shadow-lg {
+    box-shadow: 0 0 3rem rgba(10, 20, 56, 0.3) !important;
+}
+
+.shadow-none {
+    box-shadow: none !important;
+}
+
+.w-25 {
+    width: 25% !important;
+}
+
+.w-50 {
+    width: 50% !important;
+}
+
+.w-75 {
+    width: 75% !important;
+}
+
+.w-100 {
+    width: 100% !important;
+}
+
+.w-auto {
+    width: auto !important;
+}
+
+.w-10 {
+    width: 10% !important;
+}
+
+.w-20 {
+    width: 20% !important;
+}
+
+.w-30 {
+    width: 30% !important;
+}
+
+.w-40 {
+    width: 40% !important;
+}
+
+.w-60 {
+    width: 60% !important;
+}
+
+.w-70 {
+    width: 70% !important;
+}
+
+.w-80 {
+    width: 80% !important;
+}
+
+.w-90 {
+    width: 90% !important;
+}
+
+.h-25 {
+    height: 25% !important;
+}
+
+.h-50 {
+    height: 50% !important;
+}
+
+.h-75 {
+    height: 75% !important;
+}
+
+.h-100 {
+    height: 100% !important;
+}
+
+.h-auto {
+    height: auto !important;
+}
+
+.h-10 {
+    height: 10% !important;
+}
+
+.h-20 {
+    height: 20% !important;
+}
+
+.h-30 {
+    height: 30% !important;
+}
+
+.h-40 {
+    height: 40% !important;
+}
+
+.h-60 {
+    height: 60% !important;
+}
+
+.h-70 {
+    height: 70% !important;
+}
+
+.h-80 {
+    height: 80% !important;
+}
+
+.h-90 {
+    height: 90% !important;
+}
+
+.mw-100 {
+    max-width: 100% !important;
+}
+
+.mh-100 {
+    max-height: 100% !important;
+}
+
+.min-vw-100 {
+    min-width: 100vw !important;
+}
+
+.min-vh-100 {
+    min-height: 100vh !important;
+}
+
+.vw-100 {
+    width: 100vw !important;
+}
+
+.vh-100 {
+    height: 100vh !important;
+}
+
+.stretched-link::after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    pointer-events: auto;
+    content: "";
+    background-color: rgba(0, 0, 0, 0);
+}
+
+.m-0 {
+    margin: 0 !important;
+}
+
+.mt-0,
+.my-0 {
+    margin-top: 0 !important;
+}
+
+.mr-0,
+.mx-0 {
+    margin-right: 0 !important;
+}
+
+.mb-0, .figure,
+.my-0 {
+    margin-bottom: 0 !important;
+}
+
+.ml-0,
+.mx-0 {
+    margin-left: 0 !important;
+}
+
+.m-1 {
+    margin: 0.5rem !important;
+}
+
+.mt-1,
+.my-1 {
+    margin-top: 0.5rem !important;
+}
+
+.mr-1,
+.mx-1 {
+    margin-right: 0.5rem !important;
+}
+
+.mb-1,
+.my-1 {
+    margin-bottom: 0.5rem !important;
+}
+
+.ml-1,
+.mx-1 {
+    margin-left: 0.5rem !important;
+}
+
+.m-2 {
+    margin: 1rem !important;
+}
+
+.mt-2,
+.my-2 {
+    margin-top: 1rem !important;
+}
+
+.mr-2,
+.mx-2 {
+    margin-right: 1rem !important;
+}
+
+.mb-2,
+.my-2 {
+    margin-bottom: 1rem !important;
+}
+
+.ml-2,
+.mx-2 {
+    margin-left: 1rem !important;
+}
+
+.m-3 {
+    margin: 2rem !important;
+}
+
+.mt-3,
+.my-3 {
+    margin-top: 2rem !important;
+}
+
+.mr-3,
+.mx-3 {
+    margin-right: 2rem !important;
+}
+
+.mb-3,
+.my-3 {
+    margin-bottom: 2rem !important;
+}
+
+.ml-3,
+.mx-3 {
+    margin-left: 2rem !important;
+}
+
+.m-4 {
+    margin: 3rem !important;
+}
+
+.mt-4,
+.my-4 {
+    margin-top: 3rem !important;
+}
+
+.mr-4,
+.mx-4 {
+    margin-right: 3rem !important;
+}
+
+.mb-4,
+.my-4 {
+    margin-bottom: 3rem !important;
+}
+
+.ml-4,
+.mx-4 {
+    margin-left: 3rem !important;
+}
+
+.m-5 {
+    margin: 4rem !important;
+}
+
+.mt-5,
+.my-5 {
+    margin-top: 4rem !important;
+}
+
+.mr-5,
+.mx-5 {
+    margin-right: 4rem !important;
+}
+
+.mb-5,
+.my-5 {
+    margin-bottom: 4rem !important;
+}
+
+.ml-5,
+.mx-5 {
+    margin-left: 4rem !important;
+}
+
+.m-6 {
+    margin: 6rem !important;
+}
+
+.mt-6,
+.my-6 {
+    margin-top: 6rem !important;
+}
+
+.mr-6,
+.mx-6 {
+    margin-right: 6rem !important;
+}
+
+.mb-6,
+.my-6 {
+    margin-bottom: 6rem !important;
+}
+
+.ml-6,
+.mx-6 {
+    margin-left: 6rem !important;
+}
+
+.p-0 {
+    padding: 0 !important;
+}
+
+.pt-0,
+.py-0 {
+    padding-top: 0 !important;
+}
+
+.pr-0,
+.px-0 {
+    padding-right: 0 !important;
+}
+
+.pb-0,
+.py-0 {
+    padding-bottom: 0 !important;
+}
+
+.pl-0,
+.px-0 {
+    padding-left: 0 !important;
+}
+
+.p-1 {
+    padding: 0.5rem !important;
+}
+
+.pt-1,
+.py-1 {
+    padding-top: 0.5rem !important;
+}
+
+.pr-1,
+.px-1 {
+    padding-right: 0.5rem !important;
+}
+
+.pb-1,
+.py-1 {
+    padding-bottom: 0.5rem !important;
+}
+
+.pl-1,
+.px-1 {
+    padding-left: 0.5rem !important;
+}
+
+.p-2 {
+    padding: 1rem !important;
+}
+
+.pt-2,
+.py-2 {
+    padding-top: 1rem !important;
+}
+
+.pr-2,
+.px-2 {
+    padding-right: 1rem !important;
+}
+
+.pb-2,
+.py-2 {
+    padding-bottom: 1rem !important;
+}
+
+.pl-2,
+.px-2 {
+    padding-left: 1rem !important;
+}
+
+.p-3 {
+    padding: 2rem !important;
+}
+
+.pt-3,
+.py-3 {
+    padding-top: 2rem !important;
+}
+
+.pr-3,
+.px-3 {
+    padding-right: 2rem !important;
+}
+
+.pb-3,
+.py-3 {
+    padding-bottom: 2rem !important;
+}
+
+.pl-3,
+.px-3 {
+    padding-left: 2rem !important;
+}
+
+.p-4 {
+    padding: 3rem !important;
+}
+
+.pt-4,
+.py-4 {
+    padding-top: 3rem !important;
+}
+
+.pr-4,
+.px-4 {
+    padding-right: 3rem !important;
+}
+
+.pb-4,
+.py-4 {
+    padding-bottom: 3rem !important;
+}
+
+.pl-4,
+.px-4 {
+    padding-left: 3rem !important;
+}
+
+.p-5 {
+    padding: 4rem !important;
+}
+
+.pt-5,
+.py-5 {
+    padding-top: 4rem !important;
+}
+
+.pr-5,
+.px-5 {
+    padding-right: 4rem !important;
+}
+
+.pb-5,
+.py-5 {
+    padding-bottom: 4rem !important;
+}
+
+.pl-5,
+.px-5 {
+    padding-left: 4rem !important;
+}
+
+.p-6 {
+    padding: 6rem !important;
+}
+
+.pt-6,
+.py-6 {
+    padding-top: 6rem !important;
+}
+
+.pr-6,
+.px-6 {
+    padding-right: 6rem !important;
+}
+
+.pb-6,
+.py-6 {
+    padding-bottom: 6rem !important;
+}
+
+.pl-6,
+.px-6 {
+    padding-left: 6rem !important;
+}
+
+.m-n1 {
+    margin: -0.5rem !important;
+}
+
+.mt-n1,
+.my-n1 {
+    margin-top: -0.5rem !important;
+}
+
+.mr-n1,
+.mx-n1 {
+    margin-right: -0.5rem !important;
+}
+
+.mb-n1,
+.my-n1 {
+    margin-bottom: -0.5rem !important;
+}
+
+.ml-n1,
+.mx-n1 {
+    margin-left: -0.5rem !important;
+}
+
+.m-n2 {
+    margin: -1rem !important;
+}
+
+.mt-n2,
+.my-n2 {
+    margin-top: -1rem !important;
+}
+
+.mr-n2,
+.mx-n2 {
+    margin-right: -1rem !important;
+}
+
+.mb-n2,
+.my-n2 {
+    margin-bottom: -1rem !important;
+}
+
+.ml-n2,
+.mx-n2 {
+    margin-left: -1rem !important;
+}
+
+.m-n3 {
+    margin: -2rem !important;
+}
+
+.mt-n3,
+.my-n3 {
+    margin-top: -2rem !important;
+}
+
+.mr-n3,
+.mx-n3 {
+    margin-right: -2rem !important;
+}
+
+.mb-n3,
+.my-n3 {
+    margin-bottom: -2rem !important;
+}
+
+.ml-n3,
+.mx-n3 {
+    margin-left: -2rem !important;
+}
+
+.m-n4 {
+    margin: -3rem !important;
+}
+
+.mt-n4,
+.my-n4 {
+    margin-top: -3rem !important;
+}
+
+.mr-n4,
+.mx-n4 {
+    margin-right: -3rem !important;
+}
+
+.mb-n4,
+.my-n4 {
+    margin-bottom: -3rem !important;
+}
+
+.ml-n4,
+.mx-n4 {
+    margin-left: -3rem !important;
+}
+
+.m-n5 {
+    margin: -4rem !important;
+}
+
+.mt-n5,
+.my-n5 {
+    margin-top: -4rem !important;
+}
+
+.mr-n5,
+.mx-n5 {
+    margin-right: -4rem !important;
+}
+
+.mb-n5,
+.my-n5 {
+    margin-bottom: -4rem !important;
+}
+
+.ml-n5,
+.mx-n5 {
+    margin-left: -4rem !important;
+}
+
+.m-n6 {
+    margin: -6rem !important;
+}
+
+.mt-n6,
+.my-n6 {
+    margin-top: -6rem !important;
+}
+
+.mr-n6,
+.mx-n6 {
+    margin-right: -6rem !important;
+}
+
+.mb-n6,
+.my-n6 {
+    margin-bottom: -6rem !important;
+}
+
+.ml-n6,
+.mx-n6 {
+    margin-left: -6rem !important;
+}
+
+.m-auto {
+    margin: auto !important;
+}
+
+.mt-auto,
+.my-auto {
+    margin-top: auto !important;
+}
+
+.mr-auto,
+.mx-auto {
+    margin-right: auto !important;
+}
+
+.mb-auto,
+.my-auto {
+    margin-bottom: auto !important;
+}
+
+.ml-auto,
+.mx-auto {
+    margin-left: auto !important;
+}
+
+@media (min-width: 480px) {
+    .m-sm-0 {
+        margin: 0 !important;
+    }
+    .mt-sm-0,
+    .my-sm-0 {
+        margin-top: 0 !important;
+    }
+    .mr-sm-0,
+    .mx-sm-0 {
+        margin-right: 0 !important;
+    }
+    .mb-sm-0,
+    .my-sm-0 {
+        margin-bottom: 0 !important;
+    }
+    .ml-sm-0,
+    .mx-sm-0 {
+        margin-left: 0 !important;
+    }
+    .m-sm-1 {
+        margin: 0.5rem !important;
+    }
+    .mt-sm-1,
+    .my-sm-1 {
+        margin-top: 0.5rem !important;
+    }
+    .mr-sm-1,
+    .mx-sm-1 {
+        margin-right: 0.5rem !important;
+    }
+    .mb-sm-1,
+    .my-sm-1 {
+        margin-bottom: 0.5rem !important;
+    }
+    .ml-sm-1,
+    .mx-sm-1 {
+        margin-left: 0.5rem !important;
+    }
+    .m-sm-2 {
+        margin: 1rem !important;
+    }
+    .mt-sm-2,
+    .my-sm-2 {
+        margin-top: 1rem !important;
+    }
+    .mr-sm-2,
+    .mx-sm-2 {
+        margin-right: 1rem !important;
+    }
+    .mb-sm-2,
+    .my-sm-2 {
+        margin-bottom: 1rem !important;
+    }
+    .ml-sm-2,
+    .mx-sm-2 {
+        margin-left: 1rem !important;
+    }
+    .m-sm-3 {
+        margin: 2rem !important;
+    }
+    .mt-sm-3,
+    .my-sm-3 {
+        margin-top: 2rem !important;
+    }
+    .mr-sm-3,
+    .mx-sm-3 {
+        margin-right: 2rem !important;
+    }
+    .mb-sm-3,
+    .my-sm-3 {
+        margin-bottom: 2rem !important;
+    }
+    .ml-sm-3,
+    .mx-sm-3 {
+        margin-left: 2rem !important;
+    }
+    .m-sm-4 {
+        margin: 3rem !important;
+    }
+    .mt-sm-4,
+    .my-sm-4 {
+        margin-top: 3rem !important;
+    }
+    .mr-sm-4,
+    .mx-sm-4 {
+        margin-right: 3rem !important;
+    }
+    .mb-sm-4,
+    .my-sm-4 {
+        margin-bottom: 3rem !important;
+    }
+    .ml-sm-4,
+    .mx-sm-4 {
+        margin-left: 3rem !important;
+    }
+    .m-sm-5 {
+        margin: 4rem !important;
+    }
+    .mt-sm-5,
+    .my-sm-5 {
+        margin-top: 4rem !important;
+    }
+    .mr-sm-5,
+    .mx-sm-5 {
+        margin-right: 4rem !important;
+    }
+    .mb-sm-5,
+    .my-sm-5 {
+        margin-bottom: 4rem !important;
+    }
+    .ml-sm-5,
+    .mx-sm-5 {
+        margin-left: 4rem !important;
+    }
+    .m-sm-6 {
+        margin: 6rem !important;
+    }
+    .mt-sm-6,
+    .my-sm-6 {
+        margin-top: 6rem !important;
+    }
+    .mr-sm-6,
+    .mx-sm-6 {
+        margin-right: 6rem !important;
+    }
+    .mb-sm-6,
+    .my-sm-6 {
+        margin-bottom: 6rem !important;
+    }
+    .ml-sm-6,
+    .mx-sm-6 {
+        margin-left: 6rem !important;
+    }
+    .p-sm-0 {
+        padding: 0 !important;
+    }
+    .pt-sm-0,
+    .py-sm-0 {
+        padding-top: 0 !important;
+    }
+    .pr-sm-0,
+    .px-sm-0 {
+        padding-right: 0 !important;
+    }
+    .pb-sm-0,
+    .py-sm-0 {
+        padding-bottom: 0 !important;
+    }
+    .pl-sm-0,
+    .px-sm-0 {
+        padding-left: 0 !important;
+    }
+    .p-sm-1 {
+        padding: 0.5rem !important;
+    }
+    .pt-sm-1,
+    .py-sm-1 {
+        padding-top: 0.5rem !important;
+    }
+    .pr-sm-1,
+    .px-sm-1 {
+        padding-right: 0.5rem !important;
+    }
+    .pb-sm-1,
+    .py-sm-1 {
+        padding-bottom: 0.5rem !important;
+    }
+    .pl-sm-1,
+    .px-sm-1 {
+        padding-left: 0.5rem !important;
+    }
+    .p-sm-2 {
+        padding: 1rem !important;
+    }
+    .pt-sm-2,
+    .py-sm-2 {
+        padding-top: 1rem !important;
+    }
+    .pr-sm-2,
+    .px-sm-2 {
+        padding-right: 1rem !important;
+    }
+    .pb-sm-2,
+    .py-sm-2 {
+        padding-bottom: 1rem !important;
+    }
+    .pl-sm-2,
+    .px-sm-2 {
+        padding-left: 1rem !important;
+    }
+    .p-sm-3 {
+        padding: 2rem !important;
+    }
+    .pt-sm-3,
+    .py-sm-3 {
+        padding-top: 2rem !important;
+    }
+    .pr-sm-3,
+    .px-sm-3 {
+        padding-right: 2rem !important;
+    }
+    .pb-sm-3,
+    .py-sm-3 {
+        padding-bottom: 2rem !important;
+    }
+    .pl-sm-3,
+    .px-sm-3 {
+        padding-left: 2rem !important;
+    }
+    .p-sm-4 {
+        padding: 3rem !important;
+    }
+    .pt-sm-4,
+    .py-sm-4 {
+        padding-top: 3rem !important;
+    }
+    .pr-sm-4,
+    .px-sm-4 {
+        padding-right: 3rem !important;
+    }
+    .pb-sm-4,
+    .py-sm-4 {
+        padding-bottom: 3rem !important;
+    }
+    .pl-sm-4,
+    .px-sm-4 {
+        padding-left: 3rem !important;
+    }
+    .p-sm-5 {
+        padding: 4rem !important;
+    }
+    .pt-sm-5,
+    .py-sm-5 {
+        padding-top: 4rem !important;
+    }
+    .pr-sm-5,
+    .px-sm-5 {
+        padding-right: 4rem !important;
+    }
+    .pb-sm-5,
+    .py-sm-5 {
+        padding-bottom: 4rem !important;
+    }
+    .pl-sm-5,
+    .px-sm-5 {
+        padding-left: 4rem !important;
+    }
+    .p-sm-6 {
+        padding: 6rem !important;
+    }
+    .pt-sm-6,
+    .py-sm-6 {
+        padding-top: 6rem !important;
+    }
+    .pr-sm-6,
+    .px-sm-6 {
+        padding-right: 6rem !important;
+    }
+    .pb-sm-6,
+    .py-sm-6 {
+        padding-bottom: 6rem !important;
+    }
+    .pl-sm-6,
+    .px-sm-6 {
+        padding-left: 6rem !important;
+    }
+    .m-sm-n1 {
+        margin: -0.5rem !important;
+    }
+    .mt-sm-n1,
+    .my-sm-n1 {
+        margin-top: -0.5rem !important;
+    }
+    .mr-sm-n1,
+    .mx-sm-n1 {
+        margin-right: -0.5rem !important;
+    }
+    .mb-sm-n1,
+    .my-sm-n1 {
+        margin-bottom: -0.5rem !important;
+    }
+    .ml-sm-n1,
+    .mx-sm-n1 {
+        margin-left: -0.5rem !important;
+    }
+    .m-sm-n2 {
+        margin: -1rem !important;
+    }
+    .mt-sm-n2,
+    .my-sm-n2 {
+        margin-top: -1rem !important;
+    }
+    .mr-sm-n2,
+    .mx-sm-n2 {
+        margin-right: -1rem !important;
+    }
+    .mb-sm-n2,
+    .my-sm-n2 {
+        margin-bottom: -1rem !important;
+    }
+    .ml-sm-n2,
+    .mx-sm-n2 {
+        margin-left: -1rem !important;
+    }
+    .m-sm-n3 {
+        margin: -2rem !important;
+    }
+    .mt-sm-n3,
+    .my-sm-n3 {
+        margin-top: -2rem !important;
+    }
+    .mr-sm-n3,
+    .mx-sm-n3 {
+        margin-right: -2rem !important;
+    }
+    .mb-sm-n3,
+    .my-sm-n3 {
+        margin-bottom: -2rem !important;
+    }
+    .ml-sm-n3,
+    .mx-sm-n3 {
+        margin-left: -2rem !important;
+    }
+    .m-sm-n4 {
+        margin: -3rem !important;
+    }
+    .mt-sm-n4,
+    .my-sm-n4 {
+        margin-top: -3rem !important;
+    }
+    .mr-sm-n4,
+    .mx-sm-n4 {
+        margin-right: -3rem !important;
+    }
+    .mb-sm-n4,
+    .my-sm-n4 {
+        margin-bottom: -3rem !important;
+    }
+    .ml-sm-n4,
+    .mx-sm-n4 {
+        margin-left: -3rem !important;
+    }
+    .m-sm-n5 {
+        margin: -4rem !important;
+    }
+    .mt-sm-n5,
+    .my-sm-n5 {
+        margin-top: -4rem !important;
+    }
+    .mr-sm-n5,
+    .mx-sm-n5 {
+        margin-right: -4rem !important;
+    }
+    .mb-sm-n5,
+    .my-sm-n5 {
+        margin-bottom: -4rem !important;
+    }
+    .ml-sm-n5,
+    .mx-sm-n5 {
+        margin-left: -4rem !important;
+    }
+    .m-sm-n6 {
+        margin: -6rem !important;
+    }
+    .mt-sm-n6,
+    .my-sm-n6 {
+        margin-top: -6rem !important;
+    }
+    .mr-sm-n6,
+    .mx-sm-n6 {
+        margin-right: -6rem !important;
+    }
+    .mb-sm-n6,
+    .my-sm-n6 {
+        margin-bottom: -6rem !important;
+    }
+    .ml-sm-n6,
+    .mx-sm-n6 {
+        margin-left: -6rem !important;
+    }
+    .m-sm-auto {
+        margin: auto !important;
+    }
+    .mt-sm-auto,
+    .my-sm-auto {
+        margin-top: auto !important;
+    }
+    .mr-sm-auto,
+    .mx-sm-auto {
+        margin-right: auto !important;
+    }
+    .mb-sm-auto,
+    .my-sm-auto {
+        margin-bottom: auto !important;
+    }
+    .ml-sm-auto,
+    .mx-sm-auto {
+        margin-left: auto !important;
+    }
+}
+
+@media (min-width: 720px) {
+    .m-md-0 {
+        margin: 0 !important;
+    }
+    .mt-md-0,
+    .my-md-0 {
+        margin-top: 0 !important;
+    }
+    .mr-md-0,
+    .mx-md-0 {
+        margin-right: 0 !important;
+    }
+    .mb-md-0,
+    .my-md-0 {
+        margin-bottom: 0 !important;
+    }
+    .ml-md-0,
+    .mx-md-0 {
+        margin-left: 0 !important;
+    }
+    .m-md-1 {
+        margin: 0.5rem !important;
+    }
+    .mt-md-1,
+    .my-md-1 {
+        margin-top: 0.5rem !important;
+    }
+    .mr-md-1,
+    .mx-md-1 {
+        margin-right: 0.5rem !important;
+    }
+    .mb-md-1,
+    .my-md-1 {
+        margin-bottom: 0.5rem !important;
+    }
+    .ml-md-1,
+    .mx-md-1 {
+        margin-left: 0.5rem !important;
+    }
+    .m-md-2 {
+        margin: 1rem !important;
+    }
+    .mt-md-2,
+    .my-md-2 {
+        margin-top: 1rem !important;
+    }
+    .mr-md-2,
+    .mx-md-2 {
+        margin-right: 1rem !important;
+    }
+    .mb-md-2,
+    .my-md-2 {
+        margin-bottom: 1rem !important;
+    }
+    .ml-md-2,
+    .mx-md-2 {
+        margin-left: 1rem !important;
+    }
+    .m-md-3 {
+        margin: 2rem !important;
+    }
+    .mt-md-3,
+    .my-md-3 {
+        margin-top: 2rem !important;
+    }
+    .mr-md-3,
+    .mx-md-3 {
+        margin-right: 2rem !important;
+    }
+    .mb-md-3,
+    .my-md-3 {
+        margin-bottom: 2rem !important;
+    }
+    .ml-md-3,
+    .mx-md-3 {
+        margin-left: 2rem !important;
+    }
+    .m-md-4 {
+        margin: 3rem !important;
+    }
+    .mt-md-4,
+    .my-md-4 {
+        margin-top: 3rem !important;
+    }
+    .mr-md-4,
+    .mx-md-4 {
+        margin-right: 3rem !important;
+    }
+    .mb-md-4,
+    .my-md-4 {
+        margin-bottom: 3rem !important;
+    }
+    .ml-md-4,
+    .mx-md-4 {
+        margin-left: 3rem !important;
+    }
+    .m-md-5 {
+        margin: 4rem !important;
+    }
+    .mt-md-5,
+    .my-md-5 {
+        margin-top: 4rem !important;
+    }
+    .mr-md-5,
+    .mx-md-5 {
+        margin-right: 4rem !important;
+    }
+    .mb-md-5,
+    .my-md-5 {
+        margin-bottom: 4rem !important;
+    }
+    .ml-md-5,
+    .mx-md-5 {
+        margin-left: 4rem !important;
+    }
+    .m-md-6 {
+        margin: 6rem !important;
+    }
+    .mt-md-6,
+    .my-md-6 {
+        margin-top: 6rem !important;
+    }
+    .mr-md-6,
+    .mx-md-6 {
+        margin-right: 6rem !important;
+    }
+    .mb-md-6,
+    .my-md-6 {
+        margin-bottom: 6rem !important;
+    }
+    .ml-md-6,
+    .mx-md-6 {
+        margin-left: 6rem !important;
+    }
+    .p-md-0 {
+        padding: 0 !important;
+    }
+    .pt-md-0,
+    .py-md-0 {
+        padding-top: 0 !important;
+    }
+    .pr-md-0,
+    .px-md-0 {
+        padding-right: 0 !important;
+    }
+    .pb-md-0,
+    .py-md-0 {
+        padding-bottom: 0 !important;
+    }
+    .pl-md-0,
+    .px-md-0 {
+        padding-left: 0 !important;
+    }
+    .p-md-1 {
+        padding: 0.5rem !important;
+    }
+    .pt-md-1,
+    .py-md-1 {
+        padding-top: 0.5rem !important;
+    }
+    .pr-md-1,
+    .px-md-1 {
+        padding-right: 0.5rem !important;
+    }
+    .pb-md-1,
+    .py-md-1 {
+        padding-bottom: 0.5rem !important;
+    }
+    .pl-md-1,
+    .px-md-1 {
+        padding-left: 0.5rem !important;
+    }
+    .p-md-2 {
+        padding: 1rem !important;
+    }
+    .pt-md-2,
+    .py-md-2 {
+        padding-top: 1rem !important;
+    }
+    .pr-md-2,
+    .px-md-2 {
+        padding-right: 1rem !important;
+    }
+    .pb-md-2,
+    .py-md-2 {
+        padding-bottom: 1rem !important;
+    }
+    .pl-md-2,
+    .px-md-2 {
+        padding-left: 1rem !important;
+    }
+    .p-md-3 {
+        padding: 2rem !important;
+    }
+    .pt-md-3,
+    .py-md-3 {
+        padding-top: 2rem !important;
+    }
+    .pr-md-3,
+    .px-md-3 {
+        padding-right: 2rem !important;
+    }
+    .pb-md-3,
+    .py-md-3 {
+        padding-bottom: 2rem !important;
+    }
+    .pl-md-3,
+    .px-md-3 {
+        padding-left: 2rem !important;
+    }
+    .p-md-4 {
+        padding: 3rem !important;
+    }
+    .pt-md-4,
+    .py-md-4 {
+        padding-top: 3rem !important;
+    }
+    .pr-md-4,
+    .px-md-4 {
+        padding-right: 3rem !important;
+    }
+    .pb-md-4,
+    .py-md-4 {
+        padding-bottom: 3rem !important;
+    }
+    .pl-md-4,
+    .px-md-4 {
+        padding-left: 3rem !important;
+    }
+    .p-md-5 {
+        padding: 4rem !important;
+    }
+    .pt-md-5,
+    .py-md-5 {
+        padding-top: 4rem !important;
+    }
+    .pr-md-5,
+    .px-md-5 {
+        padding-right: 4rem !important;
+    }
+    .pb-md-5,
+    .py-md-5 {
+        padding-bottom: 4rem !important;
+    }
+    .pl-md-5,
+    .px-md-5 {
+        padding-left: 4rem !important;
+    }
+    .p-md-6 {
+        padding: 6rem !important;
+    }
+    .pt-md-6,
+    .py-md-6 {
+        padding-top: 6rem !important;
+    }
+    .pr-md-6,
+    .px-md-6 {
+        padding-right: 6rem !important;
+    }
+    .pb-md-6,
+    .py-md-6 {
+        padding-bottom: 6rem !important;
+    }
+    .pl-md-6,
+    .px-md-6 {
+        padding-left: 6rem !important;
+    }
+    .m-md-n1 {
+        margin: -0.5rem !important;
+    }
+    .mt-md-n1,
+    .my-md-n1 {
+        margin-top: -0.5rem !important;
+    }
+    .mr-md-n1,
+    .mx-md-n1 {
+        margin-right: -0.5rem !important;
+    }
+    .mb-md-n1,
+    .my-md-n1 {
+        margin-bottom: -0.5rem !important;
+    }
+    .ml-md-n1,
+    .mx-md-n1 {
+        margin-left: -0.5rem !important;
+    }
+    .m-md-n2 {
+        margin: -1rem !important;
+    }
+    .mt-md-n2,
+    .my-md-n2 {
+        margin-top: -1rem !important;
+    }
+    .mr-md-n2,
+    .mx-md-n2 {
+        margin-right: -1rem !important;
+    }
+    .mb-md-n2,
+    .my-md-n2 {
+        margin-bottom: -1rem !important;
+    }
+    .ml-md-n2,
+    .mx-md-n2 {
+        margin-left: -1rem !important;
+    }
+    .m-md-n3 {
+        margin: -2rem !important;
+    }
+    .mt-md-n3,
+    .my-md-n3 {
+        margin-top: -2rem !important;
+    }
+    .mr-md-n3,
+    .mx-md-n3 {
+        margin-right: -2rem !important;
+    }
+    .mb-md-n3,
+    .my-md-n3 {
+        margin-bottom: -2rem !important;
+    }
+    .ml-md-n3,
+    .mx-md-n3 {
+        margin-left: -2rem !important;
+    }
+    .m-md-n4 {
+        margin: -3rem !important;
+    }
+    .mt-md-n4,
+    .my-md-n4 {
+        margin-top: -3rem !important;
+    }
+    .mr-md-n4,
+    .mx-md-n4 {
+        margin-right: -3rem !important;
+    }
+    .mb-md-n4,
+    .my-md-n4 {
+        margin-bottom: -3rem !important;
+    }
+    .ml-md-n4,
+    .mx-md-n4 {
+        margin-left: -3rem !important;
+    }
+    .m-md-n5 {
+        margin: -4rem !important;
+    }
+    .mt-md-n5,
+    .my-md-n5 {
+        margin-top: -4rem !important;
+    }
+    .mr-md-n5,
+    .mx-md-n5 {
+        margin-right: -4rem !important;
+    }
+    .mb-md-n5,
+    .my-md-n5 {
+        margin-bottom: -4rem !important;
+    }
+    .ml-md-n5,
+    .mx-md-n5 {
+        margin-left: -4rem !important;
+    }
+    .m-md-n6 {
+        margin: -6rem !important;
+    }
+    .mt-md-n6,
+    .my-md-n6 {
+        margin-top: -6rem !important;
+    }
+    .mr-md-n6,
+    .mx-md-n6 {
+        margin-right: -6rem !important;
+    }
+    .mb-md-n6,
+    .my-md-n6 {
+        margin-bottom: -6rem !important;
+    }
+    .ml-md-n6,
+    .mx-md-n6 {
+        margin-left: -6rem !important;
+    }
+    .m-md-auto {
+        margin: auto !important;
+    }
+    .mt-md-auto,
+    .my-md-auto {
+        margin-top: auto !important;
+    }
+    .mr-md-auto,
+    .mx-md-auto {
+        margin-right: auto !important;
+    }
+    .mb-md-auto,
+    .my-md-auto {
+        margin-bottom: auto !important;
+    }
+    .ml-md-auto,
+    .mx-md-auto {
+        margin-left: auto !important;
+    }
+}
+
+@media (min-width: 960px) {
+    .m-lg-0 {
+        margin: 0 !important;
+    }
+    .mt-lg-0,
+    .my-lg-0 {
+        margin-top: 0 !important;
+    }
+    .mr-lg-0,
+    .mx-lg-0 {
+        margin-right: 0 !important;
+    }
+    .mb-lg-0,
+    .my-lg-0 {
+        margin-bottom: 0 !important;
+    }
+    .ml-lg-0,
+    .mx-lg-0 {
+        margin-left: 0 !important;
+    }
+    .m-lg-1 {
+        margin: 0.5rem !important;
+    }
+    .mt-lg-1,
+    .my-lg-1 {
+        margin-top: 0.5rem !important;
+    }
+    .mr-lg-1,
+    .mx-lg-1 {
+        margin-right: 0.5rem !important;
+    }
+    .mb-lg-1,
+    .my-lg-1 {
+        margin-bottom: 0.5rem !important;
+    }
+    .ml-lg-1,
+    .mx-lg-1 {
+        margin-left: 0.5rem !important;
+    }
+    .m-lg-2 {
+        margin: 1rem !important;
+    }
+    .mt-lg-2,
+    .my-lg-2 {
+        margin-top: 1rem !important;
+    }
+    .mr-lg-2,
+    .mx-lg-2 {
+        margin-right: 1rem !important;
+    }
+    .mb-lg-2,
+    .my-lg-2 {
+        margin-bottom: 1rem !important;
+    }
+    .ml-lg-2,
+    .mx-lg-2 {
+        margin-left: 1rem !important;
+    }
+    .m-lg-3 {
+        margin: 2rem !important;
+    }
+    .mt-lg-3,
+    .my-lg-3 {
+        margin-top: 2rem !important;
+    }
+    .mr-lg-3,
+    .mx-lg-3 {
+        margin-right: 2rem !important;
+    }
+    .mb-lg-3,
+    .my-lg-3 {
+        margin-bottom: 2rem !important;
+    }
+    .ml-lg-3,
+    .mx-lg-3 {
+        margin-left: 2rem !important;
+    }
+    .m-lg-4 {
+        margin: 3rem !important;
+    }
+    .mt-lg-4,
+    .my-lg-4 {
+        margin-top: 3rem !important;
+    }
+    .mr-lg-4,
+    .mx-lg-4 {
+        margin-right: 3rem !important;
+    }
+    .mb-lg-4,
+    .my-lg-4 {
+        margin-bottom: 3rem !important;
+    }
+    .ml-lg-4,
+    .mx-lg-4 {
+        margin-left: 3rem !important;
+    }
+    .m-lg-5 {
+        margin: 4rem !important;
+    }
+    .mt-lg-5,
+    .my-lg-5 {
+        margin-top: 4rem !important;
+    }
+    .mr-lg-5,
+    .mx-lg-5 {
+        margin-right: 4rem !important;
+    }
+    .mb-lg-5,
+    .my-lg-5 {
+        margin-bottom: 4rem !important;
+    }
+    .ml-lg-5,
+    .mx-lg-5 {
+        margin-left: 4rem !important;
+    }
+    .m-lg-6 {
+        margin: 6rem !important;
+    }
+    .mt-lg-6,
+    .my-lg-6 {
+        margin-top: 6rem !important;
+    }
+    .mr-lg-6,
+    .mx-lg-6 {
+        margin-right: 6rem !important;
+    }
+    .mb-lg-6,
+    .my-lg-6 {
+        margin-bottom: 6rem !important;
+    }
+    .ml-lg-6,
+    .mx-lg-6 {
+        margin-left: 6rem !important;
+    }
+    .p-lg-0 {
+        padding: 0 !important;
+    }
+    .pt-lg-0,
+    .py-lg-0 {
+        padding-top: 0 !important;
+    }
+    .pr-lg-0,
+    .px-lg-0 {
+        padding-right: 0 !important;
+    }
+    .pb-lg-0,
+    .py-lg-0 {
+        padding-bottom: 0 !important;
+    }
+    .pl-lg-0,
+    .px-lg-0 {
+        padding-left: 0 !important;
+    }
+    .p-lg-1 {
+        padding: 0.5rem !important;
+    }
+    .pt-lg-1,
+    .py-lg-1 {
+        padding-top: 0.5rem !important;
+    }
+    .pr-lg-1,
+    .px-lg-1 {
+        padding-right: 0.5rem !important;
+    }
+    .pb-lg-1,
+    .py-lg-1 {
+        padding-bottom: 0.5rem !important;
+    }
+    .pl-lg-1,
+    .px-lg-1 {
+        padding-left: 0.5rem !important;
+    }
+    .p-lg-2 {
+        padding: 1rem !important;
+    }
+    .pt-lg-2,
+    .py-lg-2 {
+        padding-top: 1rem !important;
+    }
+    .pr-lg-2,
+    .px-lg-2 {
+        padding-right: 1rem !important;
+    }
+    .pb-lg-2,
+    .py-lg-2 {
+        padding-bottom: 1rem !important;
+    }
+    .pl-lg-2,
+    .px-lg-2 {
+        padding-left: 1rem !important;
+    }
+    .p-lg-3 {
+        padding: 2rem !important;
+    }
+    .pt-lg-3,
+    .py-lg-3 {
+        padding-top: 2rem !important;
+    }
+    .pr-lg-3,
+    .px-lg-3 {
+        padding-right: 2rem !important;
+    }
+    .pb-lg-3,
+    .py-lg-3 {
+        padding-bottom: 2rem !important;
+    }
+    .pl-lg-3,
+    .px-lg-3 {
+        padding-left: 2rem !important;
+    }
+    .p-lg-4 {
+        padding: 3rem !important;
+    }
+    .pt-lg-4,
+    .py-lg-4 {
+        padding-top: 3rem !important;
+    }
+    .pr-lg-4,
+    .px-lg-4 {
+        padding-right: 3rem !important;
+    }
+    .pb-lg-4,
+    .py-lg-4 {
+        padding-bottom: 3rem !important;
+    }
+    .pl-lg-4,
+    .px-lg-4 {
+        padding-left: 3rem !important;
+    }
+    .p-lg-5 {
+        padding: 4rem !important;
+    }
+    .pt-lg-5,
+    .py-lg-5 {
+        padding-top: 4rem !important;
+    }
+    .pr-lg-5,
+    .px-lg-5 {
+        padding-right: 4rem !important;
+    }
+    .pb-lg-5,
+    .py-lg-5 {
+        padding-bottom: 4rem !important;
+    }
+    .pl-lg-5,
+    .px-lg-5 {
+        padding-left: 4rem !important;
+    }
+    .p-lg-6 {
+        padding: 6rem !important;
+    }
+    .pt-lg-6,
+    .py-lg-6 {
+        padding-top: 6rem !important;
+    }
+    .pr-lg-6,
+    .px-lg-6 {
+        padding-right: 6rem !important;
+    }
+    .pb-lg-6,
+    .py-lg-6 {
+        padding-bottom: 6rem !important;
+    }
+    .pl-lg-6,
+    .px-lg-6 {
+        padding-left: 6rem !important;
+    }
+    .m-lg-n1 {
+        margin: -0.5rem !important;
+    }
+    .mt-lg-n1,
+    .my-lg-n1 {
+        margin-top: -0.5rem !important;
+    }
+    .mr-lg-n1,
+    .mx-lg-n1 {
+        margin-right: -0.5rem !important;
+    }
+    .mb-lg-n1,
+    .my-lg-n1 {
+        margin-bottom: -0.5rem !important;
+    }
+    .ml-lg-n1,
+    .mx-lg-n1 {
+        margin-left: -0.5rem !important;
+    }
+    .m-lg-n2 {
+        margin: -1rem !important;
+    }
+    .mt-lg-n2,
+    .my-lg-n2 {
+        margin-top: -1rem !important;
+    }
+    .mr-lg-n2,
+    .mx-lg-n2 {
+        margin-right: -1rem !important;
+    }
+    .mb-lg-n2,
+    .my-lg-n2 {
+        margin-bottom: -1rem !important;
+    }
+    .ml-lg-n2,
+    .mx-lg-n2 {
+        margin-left: -1rem !important;
+    }
+    .m-lg-n3 {
+        margin: -2rem !important;
+    }
+    .mt-lg-n3,
+    .my-lg-n3 {
+        margin-top: -2rem !important;
+    }
+    .mr-lg-n3,
+    .mx-lg-n3 {
+        margin-right: -2rem !important;
+    }
+    .mb-lg-n3,
+    .my-lg-n3 {
+        margin-bottom: -2rem !important;
+    }
+    .ml-lg-n3,
+    .mx-lg-n3 {
+        margin-left: -2rem !important;
+    }
+    .m-lg-n4 {
+        margin: -3rem !important;
+    }
+    .mt-lg-n4,
+    .my-lg-n4 {
+        margin-top: -3rem !important;
+    }
+    .mr-lg-n4,
+    .mx-lg-n4 {
+        margin-right: -3rem !important;
+    }
+    .mb-lg-n4,
+    .my-lg-n4 {
+        margin-bottom: -3rem !important;
+    }
+    .ml-lg-n4,
+    .mx-lg-n4 {
+        margin-left: -3rem !important;
+    }
+    .m-lg-n5 {
+        margin: -4rem !important;
+    }
+    .mt-lg-n5,
+    .my-lg-n5 {
+        margin-top: -4rem !important;
+    }
+    .mr-lg-n5,
+    .mx-lg-n5 {
+        margin-right: -4rem !important;
+    }
+    .mb-lg-n5,
+    .my-lg-n5 {
+        margin-bottom: -4rem !important;
+    }
+    .ml-lg-n5,
+    .mx-lg-n5 {
+        margin-left: -4rem !important;
+    }
+    .m-lg-n6 {
+        margin: -6rem !important;
+    }
+    .mt-lg-n6,
+    .my-lg-n6 {
+        margin-top: -6rem !important;
+    }
+    .mr-lg-n6,
+    .mx-lg-n6 {
+        margin-right: -6rem !important;
+    }
+    .mb-lg-n6,
+    .my-lg-n6 {
+        margin-bottom: -6rem !important;
+    }
+    .ml-lg-n6,
+    .mx-lg-n6 {
+        margin-left: -6rem !important;
+    }
+    .m-lg-auto {
+        margin: auto !important;
+    }
+    .mt-lg-auto,
+    .my-lg-auto {
+        margin-top: auto !important;
+    }
+    .mr-lg-auto,
+    .mx-lg-auto {
+        margin-right: auto !important;
+    }
+    .mb-lg-auto,
+    .my-lg-auto {
+        margin-bottom: auto !important;
+    }
+    .ml-lg-auto,
+    .mx-lg-auto {
+        margin-left: auto !important;
+    }
+}
+
+@media (min-width: 1200px) {
+    .m-xl-0 {
+        margin: 0 !important;
+    }
+    .mt-xl-0,
+    .my-xl-0 {
+        margin-top: 0 !important;
+    }
+    .mr-xl-0,
+    .mx-xl-0 {
+        margin-right: 0 !important;
+    }
+    .mb-xl-0,
+    .my-xl-0 {
+        margin-bottom: 0 !important;
+    }
+    .ml-xl-0,
+    .mx-xl-0 {
+        margin-left: 0 !important;
+    }
+    .m-xl-1 {
+        margin: 0.5rem !important;
+    }
+    .mt-xl-1,
+    .my-xl-1 {
+        margin-top: 0.5rem !important;
+    }
+    .mr-xl-1,
+    .mx-xl-1 {
+        margin-right: 0.5rem !important;
+    }
+    .mb-xl-1,
+    .my-xl-1 {
+        margin-bottom: 0.5rem !important;
+    }
+    .ml-xl-1,
+    .mx-xl-1 {
+        margin-left: 0.5rem !important;
+    }
+    .m-xl-2 {
+        margin: 1rem !important;
+    }
+    .mt-xl-2,
+    .my-xl-2 {
+        margin-top: 1rem !important;
+    }
+    .mr-xl-2,
+    .mx-xl-2 {
+        margin-right: 1rem !important;
+    }
+    .mb-xl-2,
+    .my-xl-2 {
+        margin-bottom: 1rem !important;
+    }
+    .ml-xl-2,
+    .mx-xl-2 {
+        margin-left: 1rem !important;
+    }
+    .m-xl-3 {
+        margin: 2rem !important;
+    }
+    .mt-xl-3,
+    .my-xl-3 {
+        margin-top: 2rem !important;
+    }
+    .mr-xl-3,
+    .mx-xl-3 {
+        margin-right: 2rem !important;
+    }
+    .mb-xl-3,
+    .my-xl-3 {
+        margin-bottom: 2rem !important;
+    }
+    .ml-xl-3,
+    .mx-xl-3 {
+        margin-left: 2rem !important;
+    }
+    .m-xl-4 {
+        margin: 3rem !important;
+    }
+    .mt-xl-4,
+    .my-xl-4 {
+        margin-top: 3rem !important;
+    }
+    .mr-xl-4,
+    .mx-xl-4 {
+        margin-right: 3rem !important;
+    }
+    .mb-xl-4,
+    .my-xl-4 {
+        margin-bottom: 3rem !important;
+    }
+    .ml-xl-4,
+    .mx-xl-4 {
+        margin-left: 3rem !important;
+    }
+    .m-xl-5 {
+        margin: 4rem !important;
+    }
+    .mt-xl-5,
+    .my-xl-5 {
+        margin-top: 4rem !important;
+    }
+    .mr-xl-5,
+    .mx-xl-5 {
+        margin-right: 4rem !important;
+    }
+    .mb-xl-5,
+    .my-xl-5 {
+        margin-bottom: 4rem !important;
+    }
+    .ml-xl-5,
+    .mx-xl-5 {
+        margin-left: 4rem !important;
+    }
+    .m-xl-6 {
+        margin: 6rem !important;
+    }
+    .mt-xl-6,
+    .my-xl-6 {
+        margin-top: 6rem !important;
+    }
+    .mr-xl-6,
+    .mx-xl-6 {
+        margin-right: 6rem !important;
+    }
+    .mb-xl-6,
+    .my-xl-6 {
+        margin-bottom: 6rem !important;
+    }
+    .ml-xl-6,
+    .mx-xl-6 {
+        margin-left: 6rem !important;
+    }
+    .p-xl-0 {
+        padding: 0 !important;
+    }
+    .pt-xl-0,
+    .py-xl-0 {
+        padding-top: 0 !important;
+    }
+    .pr-xl-0,
+    .px-xl-0 {
+        padding-right: 0 !important;
+    }
+    .pb-xl-0,
+    .py-xl-0 {
+        padding-bottom: 0 !important;
+    }
+    .pl-xl-0,
+    .px-xl-0 {
+        padding-left: 0 !important;
+    }
+    .p-xl-1 {
+        padding: 0.5rem !important;
+    }
+    .pt-xl-1,
+    .py-xl-1 {
+        padding-top: 0.5rem !important;
+    }
+    .pr-xl-1,
+    .px-xl-1 {
+        padding-right: 0.5rem !important;
+    }
+    .pb-xl-1,
+    .py-xl-1 {
+        padding-bottom: 0.5rem !important;
+    }
+    .pl-xl-1,
+    .px-xl-1 {
+        padding-left: 0.5rem !important;
+    }
+    .p-xl-2 {
+        padding: 1rem !important;
+    }
+    .pt-xl-2,
+    .py-xl-2 {
+        padding-top: 1rem !important;
+    }
+    .pr-xl-2,
+    .px-xl-2 {
+        padding-right: 1rem !important;
+    }
+    .pb-xl-2,
+    .py-xl-2 {
+        padding-bottom: 1rem !important;
+    }
+    .pl-xl-2,
+    .px-xl-2 {
+        padding-left: 1rem !important;
+    }
+    .p-xl-3 {
+        padding: 2rem !important;
+    }
+    .pt-xl-3,
+    .py-xl-3 {
+        padding-top: 2rem !important;
+    }
+    .pr-xl-3,
+    .px-xl-3 {
+        padding-right: 2rem !important;
+    }
+    .pb-xl-3,
+    .py-xl-3 {
+        padding-bottom: 2rem !important;
+    }
+    .pl-xl-3,
+    .px-xl-3 {
+        padding-left: 2rem !important;
+    }
+    .p-xl-4 {
+        padding: 3rem !important;
+    }
+    .pt-xl-4,
+    .py-xl-4 {
+        padding-top: 3rem !important;
+    }
+    .pr-xl-4,
+    .px-xl-4 {
+        padding-right: 3rem !important;
+    }
+    .pb-xl-4,
+    .py-xl-4 {
+        padding-bottom: 3rem !important;
+    }
+    .pl-xl-4,
+    .px-xl-4 {
+        padding-left: 3rem !important;
+    }
+    .p-xl-5 {
+        padding: 4rem !important;
+    }
+    .pt-xl-5,
+    .py-xl-5 {
+        padding-top: 4rem !important;
+    }
+    .pr-xl-5,
+    .px-xl-5 {
+        padding-right: 4rem !important;
+    }
+    .pb-xl-5,
+    .py-xl-5 {
+        padding-bottom: 4rem !important;
+    }
+    .pl-xl-5,
+    .px-xl-5 {
+        padding-left: 4rem !important;
+    }
+    .p-xl-6 {
+        padding: 6rem !important;
+    }
+    .pt-xl-6,
+    .py-xl-6 {
+        padding-top: 6rem !important;
+    }
+    .pr-xl-6,
+    .px-xl-6 {
+        padding-right: 6rem !important;
+    }
+    .pb-xl-6,
+    .py-xl-6 {
+        padding-bottom: 6rem !important;
+    }
+    .pl-xl-6,
+    .px-xl-6 {
+        padding-left: 6rem !important;
+    }
+    .m-xl-n1 {
+        margin: -0.5rem !important;
+    }
+    .mt-xl-n1,
+    .my-xl-n1 {
+        margin-top: -0.5rem !important;
+    }
+    .mr-xl-n1,
+    .mx-xl-n1 {
+        margin-right: -0.5rem !important;
+    }
+    .mb-xl-n1,
+    .my-xl-n1 {
+        margin-bottom: -0.5rem !important;
+    }
+    .ml-xl-n1,
+    .mx-xl-n1 {
+        margin-left: -0.5rem !important;
+    }
+    .m-xl-n2 {
+        margin: -1rem !important;
+    }
+    .mt-xl-n2,
+    .my-xl-n2 {
+        margin-top: -1rem !important;
+    }
+    .mr-xl-n2,
+    .mx-xl-n2 {
+        margin-right: -1rem !important;
+    }
+    .mb-xl-n2,
+    .my-xl-n2 {
+        margin-bottom: -1rem !important;
+    }
+    .ml-xl-n2,
+    .mx-xl-n2 {
+        margin-left: -1rem !important;
+    }
+    .m-xl-n3 {
+        margin: -2rem !important;
+    }
+    .mt-xl-n3,
+    .my-xl-n3 {
+        margin-top: -2rem !important;
+    }
+    .mr-xl-n3,
+    .mx-xl-n3 {
+        margin-right: -2rem !important;
+    }
+    .mb-xl-n3,
+    .my-xl-n3 {
+        margin-bottom: -2rem !important;
+    }
+    .ml-xl-n3,
+    .mx-xl-n3 {
+        margin-left: -2rem !important;
+    }
+    .m-xl-n4 {
+        margin: -3rem !important;
+    }
+    .mt-xl-n4,
+    .my-xl-n4 {
+        margin-top: -3rem !important;
+    }
+    .mr-xl-n4,
+    .mx-xl-n4 {
+        margin-right: -3rem !important;
+    }
+    .mb-xl-n4,
+    .my-xl-n4 {
+        margin-bottom: -3rem !important;
+    }
+    .ml-xl-n4,
+    .mx-xl-n4 {
+        margin-left: -3rem !important;
+    }
+    .m-xl-n5 {
+        margin: -4rem !important;
+    }
+    .mt-xl-n5,
+    .my-xl-n5 {
+        margin-top: -4rem !important;
+    }
+    .mr-xl-n5,
+    .mx-xl-n5 {
+        margin-right: -4rem !important;
+    }
+    .mb-xl-n5,
+    .my-xl-n5 {
+        margin-bottom: -4rem !important;
+    }
+    .ml-xl-n5,
+    .mx-xl-n5 {
+        margin-left: -4rem !important;
+    }
+    .m-xl-n6 {
+        margin: -6rem !important;
+    }
+    .mt-xl-n6,
+    .my-xl-n6 {
+        margin-top: -6rem !important;
+    }
+    .mr-xl-n6,
+    .mx-xl-n6 {
+        margin-right: -6rem !important;
+    }
+    .mb-xl-n6,
+    .my-xl-n6 {
+        margin-bottom: -6rem !important;
+    }
+    .ml-xl-n6,
+    .mx-xl-n6 {
+        margin-left: -6rem !important;
+    }
+    .m-xl-auto {
+        margin: auto !important;
+    }
+    .mt-xl-auto,
+    .my-xl-auto {
+        margin-top: auto !important;
+    }
+    .mr-xl-auto,
+    .mx-xl-auto {
+        margin-right: auto !important;
+    }
+    .mb-xl-auto,
+    .my-xl-auto {
+        margin-bottom: auto !important;
+    }
+    .ml-xl-auto,
+    .mx-xl-auto {
+        margin-left: auto !important;
+    }
+}
+
+@media (min-width: 1440px) {
+    .m-xxl-0 {
+        margin: 0 !important;
+    }
+    .mt-xxl-0,
+    .my-xxl-0 {
+        margin-top: 0 !important;
+    }
+    .mr-xxl-0,
+    .mx-xxl-0 {
+        margin-right: 0 !important;
+    }
+    .mb-xxl-0,
+    .my-xxl-0 {
+        margin-bottom: 0 !important;
+    }
+    .ml-xxl-0,
+    .mx-xxl-0 {
+        margin-left: 0 !important;
+    }
+    .m-xxl-1 {
+        margin: 0.5rem !important;
+    }
+    .mt-xxl-1,
+    .my-xxl-1 {
+        margin-top: 0.5rem !important;
+    }
+    .mr-xxl-1,
+    .mx-xxl-1 {
+        margin-right: 0.5rem !important;
+    }
+    .mb-xxl-1,
+    .my-xxl-1 {
+        margin-bottom: 0.5rem !important;
+    }
+    .ml-xxl-1,
+    .mx-xxl-1 {
+        margin-left: 0.5rem !important;
+    }
+    .m-xxl-2 {
+        margin: 1rem !important;
+    }
+    .mt-xxl-2,
+    .my-xxl-2 {
+        margin-top: 1rem !important;
+    }
+    .mr-xxl-2,
+    .mx-xxl-2 {
+        margin-right: 1rem !important;
+    }
+    .mb-xxl-2,
+    .my-xxl-2 {
+        margin-bottom: 1rem !important;
+    }
+    .ml-xxl-2,
+    .mx-xxl-2 {
+        margin-left: 1rem !important;
+    }
+    .m-xxl-3 {
+        margin: 2rem !important;
+    }
+    .mt-xxl-3,
+    .my-xxl-3 {
+        margin-top: 2rem !important;
+    }
+    .mr-xxl-3,
+    .mx-xxl-3 {
+        margin-right: 2rem !important;
+    }
+    .mb-xxl-3,
+    .my-xxl-3 {
+        margin-bottom: 2rem !important;
+    }
+    .ml-xxl-3,
+    .mx-xxl-3 {
+        margin-left: 2rem !important;
+    }
+    .m-xxl-4 {
+        margin: 3rem !important;
+    }
+    .mt-xxl-4,
+    .my-xxl-4 {
+        margin-top: 3rem !important;
+    }
+    .mr-xxl-4,
+    .mx-xxl-4 {
+        margin-right: 3rem !important;
+    }
+    .mb-xxl-4,
+    .my-xxl-4 {
+        margin-bottom: 3rem !important;
+    }
+    .ml-xxl-4,
+    .mx-xxl-4 {
+        margin-left: 3rem !important;
+    }
+    .m-xxl-5 {
+        margin: 4rem !important;
+    }
+    .mt-xxl-5,
+    .my-xxl-5 {
+        margin-top: 4rem !important;
+    }
+    .mr-xxl-5,
+    .mx-xxl-5 {
+        margin-right: 4rem !important;
+    }
+    .mb-xxl-5,
+    .my-xxl-5 {
+        margin-bottom: 4rem !important;
+    }
+    .ml-xxl-5,
+    .mx-xxl-5 {
+        margin-left: 4rem !important;
+    }
+    .m-xxl-6 {
+        margin: 6rem !important;
+    }
+    .mt-xxl-6,
+    .my-xxl-6 {
+        margin-top: 6rem !important;
+    }
+    .mr-xxl-6,
+    .mx-xxl-6 {
+        margin-right: 6rem !important;
+    }
+    .mb-xxl-6,
+    .my-xxl-6 {
+        margin-bottom: 6rem !important;
+    }
+    .ml-xxl-6,
+    .mx-xxl-6 {
+        margin-left: 6rem !important;
+    }
+    .p-xxl-0 {
+        padding: 0 !important;
+    }
+    .pt-xxl-0,
+    .py-xxl-0 {
+        padding-top: 0 !important;
+    }
+    .pr-xxl-0,
+    .px-xxl-0 {
+        padding-right: 0 !important;
+    }
+    .pb-xxl-0,
+    .py-xxl-0 {
+        padding-bottom: 0 !important;
+    }
+    .pl-xxl-0,
+    .px-xxl-0 {
+        padding-left: 0 !important;
+    }
+    .p-xxl-1 {
+        padding: 0.5rem !important;
+    }
+    .pt-xxl-1,
+    .py-xxl-1 {
+        padding-top: 0.5rem !important;
+    }
+    .pr-xxl-1,
+    .px-xxl-1 {
+        padding-right: 0.5rem !important;
+    }
+    .pb-xxl-1,
+    .py-xxl-1 {
+        padding-bottom: 0.5rem !important;
+    }
+    .pl-xxl-1,
+    .px-xxl-1 {
+        padding-left: 0.5rem !important;
+    }
+    .p-xxl-2 {
+        padding: 1rem !important;
+    }
+    .pt-xxl-2,
+    .py-xxl-2 {
+        padding-top: 1rem !important;
+    }
+    .pr-xxl-2,
+    .px-xxl-2 {
+        padding-right: 1rem !important;
+    }
+    .pb-xxl-2,
+    .py-xxl-2 {
+        padding-bottom: 1rem !important;
+    }
+    .pl-xxl-2,
+    .px-xxl-2 {
+        padding-left: 1rem !important;
+    }
+    .p-xxl-3 {
+        padding: 2rem !important;
+    }
+    .pt-xxl-3,
+    .py-xxl-3 {
+        padding-top: 2rem !important;
+    }
+    .pr-xxl-3,
+    .px-xxl-3 {
+        padding-right: 2rem !important;
+    }
+    .pb-xxl-3,
+    .py-xxl-3 {
+        padding-bottom: 2rem !important;
+    }
+    .pl-xxl-3,
+    .px-xxl-3 {
+        padding-left: 2rem !important;
+    }
+    .p-xxl-4 {
+        padding: 3rem !important;
+    }
+    .pt-xxl-4,
+    .py-xxl-4 {
+        padding-top: 3rem !important;
+    }
+    .pr-xxl-4,
+    .px-xxl-4 {
+        padding-right: 3rem !important;
+    }
+    .pb-xxl-4,
+    .py-xxl-4 {
+        padding-bottom: 3rem !important;
+    }
+    .pl-xxl-4,
+    .px-xxl-4 {
+        padding-left: 3rem !important;
+    }
+    .p-xxl-5 {
+        padding: 4rem !important;
+    }
+    .pt-xxl-5,
+    .py-xxl-5 {
+        padding-top: 4rem !important;
+    }
+    .pr-xxl-5,
+    .px-xxl-5 {
+        padding-right: 4rem !important;
+    }
+    .pb-xxl-5,
+    .py-xxl-5 {
+        padding-bottom: 4rem !important;
+    }
+    .pl-xxl-5,
+    .px-xxl-5 {
+        padding-left: 4rem !important;
+    }
+    .p-xxl-6 {
+        padding: 6rem !important;
+    }
+    .pt-xxl-6,
+    .py-xxl-6 {
+        padding-top: 6rem !important;
+    }
+    .pr-xxl-6,
+    .px-xxl-6 {
+        padding-right: 6rem !important;
+    }
+    .pb-xxl-6,
+    .py-xxl-6 {
+        padding-bottom: 6rem !important;
+    }
+    .pl-xxl-6,
+    .px-xxl-6 {
+        padding-left: 6rem !important;
+    }
+    .m-xxl-n1 {
+        margin: -0.5rem !important;
+    }
+    .mt-xxl-n1,
+    .my-xxl-n1 {
+        margin-top: -0.5rem !important;
+    }
+    .mr-xxl-n1,
+    .mx-xxl-n1 {
+        margin-right: -0.5rem !important;
+    }
+    .mb-xxl-n1,
+    .my-xxl-n1 {
+        margin-bottom: -0.5rem !important;
+    }
+    .ml-xxl-n1,
+    .mx-xxl-n1 {
+        margin-left: -0.5rem !important;
+    }
+    .m-xxl-n2 {
+        margin: -1rem !important;
+    }
+    .mt-xxl-n2,
+    .my-xxl-n2 {
+        margin-top: -1rem !important;
+    }
+    .mr-xxl-n2,
+    .mx-xxl-n2 {
+        margin-right: -1rem !important;
+    }
+    .mb-xxl-n2,
+    .my-xxl-n2 {
+        margin-bottom: -1rem !important;
+    }
+    .ml-xxl-n2,
+    .mx-xxl-n2 {
+        margin-left: -1rem !important;
+    }
+    .m-xxl-n3 {
+        margin: -2rem !important;
+    }
+    .mt-xxl-n3,
+    .my-xxl-n3 {
+        margin-top: -2rem !important;
+    }
+    .mr-xxl-n3,
+    .mx-xxl-n3 {
+        margin-right: -2rem !important;
+    }
+    .mb-xxl-n3,
+    .my-xxl-n3 {
+        margin-bottom: -2rem !important;
+    }
+    .ml-xxl-n3,
+    .mx-xxl-n3 {
+        margin-left: -2rem !important;
+    }
+    .m-xxl-n4 {
+        margin: -3rem !important;
+    }
+    .mt-xxl-n4,
+    .my-xxl-n4 {
+        margin-top: -3rem !important;
+    }
+    .mr-xxl-n4,
+    .mx-xxl-n4 {
+        margin-right: -3rem !important;
+    }
+    .mb-xxl-n4,
+    .my-xxl-n4 {
+        margin-bottom: -3rem !important;
+    }
+    .ml-xxl-n4,
+    .mx-xxl-n4 {
+        margin-left: -3rem !important;
+    }
+    .m-xxl-n5 {
+        margin: -4rem !important;
+    }
+    .mt-xxl-n5,
+    .my-xxl-n5 {
+        margin-top: -4rem !important;
+    }
+    .mr-xxl-n5,
+    .mx-xxl-n5 {
+        margin-right: -4rem !important;
+    }
+    .mb-xxl-n5,
+    .my-xxl-n5 {
+        margin-bottom: -4rem !important;
+    }
+    .ml-xxl-n5,
+    .mx-xxl-n5 {
+        margin-left: -4rem !important;
+    }
+    .m-xxl-n6 {
+        margin: -6rem !important;
+    }
+    .mt-xxl-n6,
+    .my-xxl-n6 {
+        margin-top: -6rem !important;
+    }
+    .mr-xxl-n6,
+    .mx-xxl-n6 {
+        margin-right: -6rem !important;
+    }
+    .mb-xxl-n6,
+    .my-xxl-n6 {
+        margin-bottom: -6rem !important;
+    }
+    .ml-xxl-n6,
+    .mx-xxl-n6 {
+        margin-left: -6rem !important;
+    }
+    .m-xxl-auto {
+        margin: auto !important;
+    }
+    .mt-xxl-auto,
+    .my-xxl-auto {
+        margin-top: auto !important;
+    }
+    .mr-xxl-auto,
+    .mx-xxl-auto {
+        margin-right: auto !important;
+    }
+    .mb-xxl-auto,
+    .my-xxl-auto {
+        margin-bottom: auto !important;
+    }
+    .ml-xxl-auto,
+    .mx-xxl-auto {
+        margin-left: auto !important;
+    }
+}
+
+.text-monospace {
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !important;
+}
+
+.text-justify {
+    text-align: justify !important;
+}
+
+.text-wrap {
+    white-space: normal !important;
+}
+
+.text-nowrap {
+    white-space: nowrap !important;
+}
+
+.text-truncate, .wrap-file-input .file-input-label .file-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.text-left {
+    text-align: left !important;
+}
+
+.text-right {
+    text-align: right !important;
+}
+
+.text-center {
+    text-align: center !important;
+}
+
+@media (min-width: 480px) {
+    .text-sm-left {
+        text-align: left !important;
+    }
+    .text-sm-right {
+        text-align: right !important;
+    }
+    .text-sm-center {
+        text-align: center !important;
+    }
+}
+
+@media (min-width: 720px) {
+    .text-md-left {
+        text-align: left !important;
+    }
+    .text-md-right {
+        text-align: right !important;
+    }
+    .text-md-center {
+        text-align: center !important;
+    }
+}
+
+@media (min-width: 960px) {
+    .text-lg-left {
+        text-align: left !important;
+    }
+    .text-lg-right {
+        text-align: right !important;
+    }
+    .text-lg-center {
+        text-align: center !important;
+    }
+}
+
+@media (min-width: 1200px) {
+    .text-xl-left {
+        text-align: left !important;
+    }
+    .text-xl-right {
+        text-align: right !important;
+    }
+    .text-xl-center {
+        text-align: center !important;
+    }
+}
+
+@media (min-width: 1440px) {
+    .text-xxl-left {
+        text-align: left !important;
+    }
+    .text-xxl-right {
+        text-align: right !important;
+    }
+    .text-xxl-center {
+        text-align: center !important;
+    }
+}
+
+.text-lowercase {
+    text-transform: lowercase !important;
+}
+
+.text-uppercase {
+    text-transform: uppercase !important;
+}
+
+.text-capitalize {
+    text-transform: capitalize !important;
+}
+
+.font-weight-light {
+    font-weight: 300 !important;
+}
+
+.font-weight-lighter {
+    font-weight: lighter !important;
+}
+
+.font-weight-normal, .wrap-file-input .file-input-label .file-name {
+    font-weight: 400 !important;
+}
+
+.font-weight-bold {
+    font-weight: 700 !important;
+}
+
+.font-weight-bolder {
+    font-weight: bolder !important;
+}
+
+.font-italic {
+    font-style: italic !important;
+}
+
+.text-white {
+    color: #fff !important;
+}
+
+.text-primary {
+    color: #181A7B !important;
+}
+
+a.text-primary:hover, a.text-primary:focus {
+    color: #0c0c3b !important;
+}
+
+.text-secondary {
+    color: #3B6CF6 !important;
+}
+
+a.text-secondary:hover, a.text-secondary:focus {
+    color: #0a41da !important;
+}
+
+.text-success {
+    color: #21883f !important;
+}
+
+a.text-success:hover, a.text-success:focus {
+    color: #124a22 !important;
+}
+
+.text-info {
+    color: #A513B6 !important;
+}
+
+a.text-info:hover, a.text-info:focus {
+    color: #660c71 !important;
+}
+
+.text-warning {
+    color: #ffc107 !important;
+}
+
+a.text-warning:hover, a.text-warning:focus {
+    color: #ba8b00 !important;
+}
+
+.text-danger {
+    color: #ea172b !important;
+}
+
+a.text-danger:hover, a.text-danger:focus {
+    color: #a60f1d !important;
+}
+
+.text-light {
+    color: #e6ecf7 !important;
+}
+
+a.text-light:hover, a.text-light:focus {
+    color: #acc0e4 !important;
+}
+
+.text-dark {
+    color: #0A1438 !important;
+}
+
+a.text-dark:hover, a.text-dark:focus {
+    color: black !important;
+}
+
+.text-white {
+    color: #fff !important;
+}
+
+a.text-white:hover, a.text-white:focus {
+    color: #d9d9d9 !important;
+}
+
+.text-black {
+    color: #000 !important;
+}
+
+a.text-black:hover, a.text-black:focus {
+    color: black !important;
+}
+
+.text-body {
+    color: #212529 !important;
+}
+
+.text-muted {
+    color: #495057 !important;
+}
+
+.text-black-50 {
+    color: rgba(0, 0, 0, 0.5) !important;
+}
+
+.text-white-50 {
+    color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.text-hide {
+    font: 0/0 a;
+    color: transparent;
+    text-shadow: none;
+    background-color: transparent;
+    border: 0;
+}
+
+.text-decoration-none {
+    text-decoration: none !important;
+}
+
+.text-break {
+    word-break: break-word !important;
+    overflow-wrap: break-word !important;
+}
+
+.text-reset, .alert-text a {
+    color: inherit !important;
+}
+
+.visible {
+    visibility: visible !important;
+}
+
+.invisible {
+    visibility: hidden !important;
+}
+
+/*
+
+In this file:
+
+// A. Linear gradient
+// B. Background image
+
+*/
+/*
+
+In this file:
+
+// A. Generic tags
+// B. Margins
+// C. Accessibility
+// D. Forms
+// E. Tables
+// F. Font size media queries
+// G. Sticky top
+// H. Internet Explorer
+
+*/
+body {
+    position: relative;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    overflow-x: hidden;
+    max-width: 3000px;
+    font-size: 1.167rem;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.figure {
+    margin-block-start: 0 !important;
+    margin-block-end: 0 !important;
+    margin-inline-start: 0 !important;
+    margin-inline-end: 0 !important;
+}
+
+h1:last-child,
+h2:last-child,
+h3:last-child,
+h4:last-child,
+h5:last-child,
+p:last-child,
+a:last-child,
+ul:last-child,
+li:last-child,
+dl:last-child,
+dd:last-child,
+address:last-child {
+    margin-bottom: 0;
+}
+
+hr {
+    margin: 0;
+}
+
+html[dir="rtl"] .text-right {
+    text-align: left !important;
+}
+
+html[dir="rtl"] .text-left {
+    text-align: right !important;
+}
+
+html[dir="rtl"] [class*="fa"][class*="arrow"], html[dir="rtl"] [class*="fa"][class*="chevron"], html[dir="rtl"] [class*="fa"][class*="angle"], html[dir="rtl"] [class*="fa"][class*="caret"] {
+    transform: scaleX(-1);
+}
+
+html[dir="rtl"] select:not(.notranslate):not(.goog-te-combo) {
+    background-position-x: 0.75rem !important;
+    padding: 0.375rem 0.75rem 0.375rem 1.75rem;
+}
+
+html[dir="rtl"] select.notranslate {
+    text-align: left !important;
+}
+
+html[dir="rtl"] button > font {
+    display: inline;
+    line-height: 0;
+}
+
+html[dir="rtl"] body,
+html[dir="rtl"] .dropdown-menu {
+    text-align: right;
+}
+
+html[dir="rtl"] #nav-primary .nav:not(.nav-pills) .dropdown-menu {
+    right: 0;
+    left: unset;
+}
+
+html[dir="rtl"] .extensible-list:not(.justify-content-center) .horizontal, html[dir="rtl"] [id="languages"] ul:not(.justify-content-center) .horizontal, [id="languages"] html[dir="rtl"] ul:not(.justify-content-center) .horizontal {
+    justify-content: flex-start !important;
+}
+
+html[dir="rtl"] .accordion-group [data-toggle="collapse"]::after,
+html[dir="rtl"] .btn-toggle [data-toggle="collapse"]::after {
+    margin-left: 0;
+    margin-right: 1rem;
+}
+
+html[dir="rtl"] .custom-control-label::before, html[dir="rtl"] .custom-control-label::after {
+    right: -1.5rem;
+}
+
+html[dir="rtl"] .custom-control {
+    padding-right: 1.5rem;
+}
+
+@media (min-width: 1200px) {
+    html[dir="rtl"] .sidebar-fixed-width {
+        border-left: none;
+        border-right: 1px solid #dee2e6;
+    }
+}
+
+html[dir="rtl"] #global-header .nav-item-search button {
+    right: unset;
+    left: 1rem;
+}
+
+html[dir="rtl"] #global-header .nav-item-search input {
+    padding-left: calc(28px + 1rem);
+    padding-right: 1rem;
+}
+
+html[dir="rtl"] [class*="border-"][class*="-right"] {
+    border-right-width: 0 !important;
+    border-left-width: 1px !important;
+}
+
+html[dir="rtl"] [class*="border-"][class*="-left"] {
+    border-right-width: 1px !important;
+    border-left-width: 0 !important;
+}
+
+html[dir="rtl"] [class*="offset-"] {
+    margin-left: 0;
+}
+
+@media (min-width: 0) {
+    html[dir="rtl"] .offset-1 {
+        margin-right: calc(100% / 12 * 1);
+    }
+    html[dir="rtl"] .offset-2 {
+        margin-right: calc(100% / 12 * 2);
+    }
+    html[dir="rtl"] .offset-3 {
+        margin-right: calc(100% / 12 * 3);
+    }
+    html[dir="rtl"] .offset-4 {
+        margin-right: calc(100% / 12 * 4);
+    }
+    html[dir="rtl"] .offset-5 {
+        margin-right: calc(100% / 12 * 5);
+    }
+    html[dir="rtl"] .offset-6 {
+        margin-right: calc(100% / 12 * 6);
+    }
+    html[dir="rtl"] .offset-7 {
+        margin-right: calc(100% / 12 * 7);
+    }
+    html[dir="rtl"] .offset-8 {
+        margin-right: calc(100% / 12 * 8);
+    }
+    html[dir="rtl"] .offset-9 {
+        margin-right: calc(100% / 12 * 9);
+    }
+    html[dir="rtl"] .offset-10 {
+        margin-right: calc(100% / 12 * 10);
+    }
+    html[dir="rtl"] .offset-11 {
+        margin-right: calc(100% / 12 * 11);
+    }
+}
+
+@media (min-width: 480px) {
+    html[dir="rtl"] .offset-sm-1 {
+        margin-right: calc(100% / 12 * 1);
+    }
+    html[dir="rtl"] .offset-sm-2 {
+        margin-right: calc(100% / 12 * 2);
+    }
+    html[dir="rtl"] .offset-sm-3 {
+        margin-right: calc(100% / 12 * 3);
+    }
+    html[dir="rtl"] .offset-sm-4 {
+        margin-right: calc(100% / 12 * 4);
+    }
+    html[dir="rtl"] .offset-sm-5 {
+        margin-right: calc(100% / 12 * 5);
+    }
+    html[dir="rtl"] .offset-sm-6 {
+        margin-right: calc(100% / 12 * 6);
+    }
+    html[dir="rtl"] .offset-sm-7 {
+        margin-right: calc(100% / 12 * 7);
+    }
+    html[dir="rtl"] .offset-sm-8 {
+        margin-right: calc(100% / 12 * 8);
+    }
+    html[dir="rtl"] .offset-sm-9 {
+        margin-right: calc(100% / 12 * 9);
+    }
+    html[dir="rtl"] .offset-sm-10 {
+        margin-right: calc(100% / 12 * 10);
+    }
+    html[dir="rtl"] .offset-sm-11 {
+        margin-right: calc(100% / 12 * 11);
+    }
+}
+
+@media (min-width: 720px) {
+    html[dir="rtl"] .offset-md-1 {
+        margin-right: calc(100% / 12 * 1);
+    }
+    html[dir="rtl"] .offset-md-2 {
+        margin-right: calc(100% / 12 * 2);
+    }
+    html[dir="rtl"] .offset-md-3 {
+        margin-right: calc(100% / 12 * 3);
+    }
+    html[dir="rtl"] .offset-md-4 {
+        margin-right: calc(100% / 12 * 4);
+    }
+    html[dir="rtl"] .offset-md-5 {
+        margin-right: calc(100% / 12 * 5);
+    }
+    html[dir="rtl"] .offset-md-6 {
+        margin-right: calc(100% / 12 * 6);
+    }
+    html[dir="rtl"] .offset-md-7 {
+        margin-right: calc(100% / 12 * 7);
+    }
+    html[dir="rtl"] .offset-md-8 {
+        margin-right: calc(100% / 12 * 8);
+    }
+    html[dir="rtl"] .offset-md-9 {
+        margin-right: calc(100% / 12 * 9);
+    }
+    html[dir="rtl"] .offset-md-10 {
+        margin-right: calc(100% / 12 * 10);
+    }
+    html[dir="rtl"] .offset-md-11 {
+        margin-right: calc(100% / 12 * 11);
+    }
+}
+
+@media (min-width: 960px) {
+    html[dir="rtl"] .offset-lg-1 {
+        margin-right: calc(100% / 12 * 1);
+    }
+    html[dir="rtl"] .offset-lg-2 {
+        margin-right: calc(100% / 12 * 2);
+    }
+    html[dir="rtl"] .offset-lg-3 {
+        margin-right: calc(100% / 12 * 3);
+    }
+    html[dir="rtl"] .offset-lg-4 {
+        margin-right: calc(100% / 12 * 4);
+    }
+    html[dir="rtl"] .offset-lg-5 {
+        margin-right: calc(100% / 12 * 5);
+    }
+    html[dir="rtl"] .offset-lg-6 {
+        margin-right: calc(100% / 12 * 6);
+    }
+    html[dir="rtl"] .offset-lg-7 {
+        margin-right: calc(100% / 12 * 7);
+    }
+    html[dir="rtl"] .offset-lg-8 {
+        margin-right: calc(100% / 12 * 8);
+    }
+    html[dir="rtl"] .offset-lg-9 {
+        margin-right: calc(100% / 12 * 9);
+    }
+    html[dir="rtl"] .offset-lg-10 {
+        margin-right: calc(100% / 12 * 10);
+    }
+    html[dir="rtl"] .offset-lg-11 {
+        margin-right: calc(100% / 12 * 11);
+    }
+}
+
+@media (min-width: 1200px) {
+    html[dir="rtl"] .offset-xl-1 {
+        margin-right: calc(100% / 12 * 1);
+    }
+    html[dir="rtl"] .offset-xl-2 {
+        margin-right: calc(100% / 12 * 2);
+    }
+    html[dir="rtl"] .offset-xl-3 {
+        margin-right: calc(100% / 12 * 3);
+    }
+    html[dir="rtl"] .offset-xl-4 {
+        margin-right: calc(100% / 12 * 4);
+    }
+    html[dir="rtl"] .offset-xl-5 {
+        margin-right: calc(100% / 12 * 5);
+    }
+    html[dir="rtl"] .offset-xl-6 {
+        margin-right: calc(100% / 12 * 6);
+    }
+    html[dir="rtl"] .offset-xl-7 {
+        margin-right: calc(100% / 12 * 7);
+    }
+    html[dir="rtl"] .offset-xl-8 {
+        margin-right: calc(100% / 12 * 8);
+    }
+    html[dir="rtl"] .offset-xl-9 {
+        margin-right: calc(100% / 12 * 9);
+    }
+    html[dir="rtl"] .offset-xl-10 {
+        margin-right: calc(100% / 12 * 10);
+    }
+    html[dir="rtl"] .offset-xl-11 {
+        margin-right: calc(100% / 12 * 11);
+    }
+}
+
+@media (min-width: 1440px) {
+    html[dir="rtl"] .offset-xxl-1 {
+        margin-right: calc(100% / 12 * 1);
+    }
+    html[dir="rtl"] .offset-xxl-2 {
+        margin-right: calc(100% / 12 * 2);
+    }
+    html[dir="rtl"] .offset-xxl-3 {
+        margin-right: calc(100% / 12 * 3);
+    }
+    html[dir="rtl"] .offset-xxl-4 {
+        margin-right: calc(100% / 12 * 4);
+    }
+    html[dir="rtl"] .offset-xxl-5 {
+        margin-right: calc(100% / 12 * 5);
+    }
+    html[dir="rtl"] .offset-xxl-6 {
+        margin-right: calc(100% / 12 * 6);
+    }
+    html[dir="rtl"] .offset-xxl-7 {
+        margin-right: calc(100% / 12 * 7);
+    }
+    html[dir="rtl"] .offset-xxl-8 {
+        margin-right: calc(100% / 12 * 8);
+    }
+    html[dir="rtl"] .offset-xxl-9 {
+        margin-right: calc(100% / 12 * 9);
+    }
+    html[dir="rtl"] .offset-xxl-10 {
+        margin-right: calc(100% / 12 * 10);
+    }
+    html[dir="rtl"] .offset-xxl-11 {
+        margin-right: calc(100% / 12 * 11);
+    }
+}
+
+a:hover, a:focus,
+.btn:hover,
+.btn:focus,
+.nav-link:hover,
+.nav-link:focus,
+.nav-item:hover,
+.nav-item:focus,
+.dropdown-item:hover,
+.dropdown-item:focus {
+    text-decoration: underline;
+}
+
+.btn-toggle [data-toggle="collapse"]:hover, .btn-toggle [data-toggle="collapse"]:focus,
+.accordion-group [data-toggle="collapse"]:hover,
+.accordion-group [data-toggle="collapse"]:focus,
+a.card:hover,
+a.card:focus,
+#back-to-top a:hover,
+#back-to-top a:focus,
+.btn.file-choose:hover,
+.btn.file-choose:focus {
+    text-decoration: none;
+}
+
+.btn-toggle [data-toggle="collapse"]:hover > span.title, .btn-toggle [data-toggle="collapse"]:focus > span.title,
+.accordion-group [data-toggle="collapse"]:hover > span.title,
+.accordion-group [data-toggle="collapse"]:focus > span.title,
+a.card:hover > span.title,
+a.card:focus > span.title,
+#back-to-top a:hover > span.title,
+#back-to-top a:focus > span.title,
+.btn.file-choose:hover > span.title,
+.btn.file-choose:focus > span.title {
+    text-decoration: underline;
+}
+
+input[type="file"]:focus + label .title {
+    text-decoration: underline;
+}
+
+.disabled:hover, .disabled:focus {
+    text-decoration: none;
+    box-shadow: none;
+    cursor: not-allowed;
+}
+
+a:not(.btn).disabled {
+    opacity: 0.5;
+}
+
+.has-icon:hover, .wrap-file-input .file-input-label .file-choose:hover, .has-icon:focus, .wrap-file-input .file-input-label .file-choose:focus {
+    text-decoration: none !important;
+}
+
+.has-icon:hover span.title, .wrap-file-input .file-input-label .file-choose:hover span.title, .has-icon:focus span.title, .wrap-file-input .file-input-label .file-choose:focus span.title {
+    text-decoration: underline;
+}
+
+.has-icon.active span.title, .wrap-file-input .file-input-label .active.file-choose span.title {
+    text-decoration: underline;
+}
+
+#primary-content p > a:not([class]) {
+    text-decoration: underline;
+}
+
+legend,
+.legend {
+    display: block;
+    float: left;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    line-height: 1.5;
+}
+
+legend + *,
+.legend + * {
+    clear: both;
+}
+
+fieldset {
+    border: 1px solid #dee2e6;
+    margin-bottom: 4rem;
+}
+
+select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+}
+
+label,
+.label {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.custom-control-label::before {
+    box-shadow: 0 0 0 1px #777677;
+}
+
+.custom-checkbox .custom-control-label::before {
+    border-radius: 0;
+}
+
+#google_translate_element {
+    text-align: center;
+}
+
+#google_translate_element select {
+    margin-bottom: 0.5rem;
+}
+
+#google_translate_element .goog-logo-link {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+@media (max-width: 959.98px) {
+    .display-1 {
+        font-size: 4.5rem;
+    }
+    .display-2 {
+        font-size: 4.125rem;
+    }
+    .display-3 {
+        font-size: 3.375rem;
+    }
+    .display-4 {
+        font-size: 2.625rem;
+    }
+}
+
+@media (max-width: 719.98px) {
+    main .fs-xl {
+        font-size: 1.25rem;
+    }
+    main .fs-lg {
+        font-size: 1.167rem;
+    }
+}
+
+@supports (position: -webkit-sticky) or (position: sticky) {
+    .sticky-top {
+        position: sticky;
+        position: -webkit-sticky;
+        top: 0;
+        z-index: 1020;
+    }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+    .card,
+    .figure {
+        display: block !important;
+    }
+    .narrow,
+    .medium {
+        border-top: 1px solid transparent;
+    }
+    .banner-with-background {
+        height: 1em;
+    }
+}
+
+/*
+
+In this file:
+
+// A. Font sizes
+// B. Additional widths
+// C. Responsive borders
+// D. Opacities
+// E. Text shadows
+// F. No button style
+// G. Has icon
+// H. Paragraph margin lists
+// I. Z-index
+
+*/
+.fs-sm {
+    font-size: 0.875rem;
+}
+
+.fs-md {
+    font-size: 1rem;
+}
+
+.fs-rg {
+    font-size: 1.167rem;
+}
+
+.fs-lg {
+    font-size: 1.25rem;
+}
+
+.fs-xl {
+    font-size: 1.5rem;
+}
+
+.narrow,
+.narrow-2,
+.medium,
+.wide {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.narrow-2 {
+    max-width: 40rem;
+}
+
+.narrow,
+.narrow-width {
+    max-width: 40rem;
+}
+
+.medium,
+.medium-width {
+    max-width: 50rem;
+}
+
+.wide {
+    max-width: 1680px;
+}
+
+.border-xs-0 {
+    border: 0 !important;
+}
+
+.border-xs {
+    border-width: 0;
+    border-color: #dee2e6;
+    border-style: solid;
+    border-width: 1px !important;
+}
+
+.border-xs-top-0 {
+    border-top: 0 !important;
+}
+
+.border-xs-top {
+    border-width: 0;
+    border-color: #dee2e6;
+    border-style: solid;
+    border-top-width: 1px !important;
+}
+
+.border-xs-right-0 {
+    border-right: 0 !important;
+}
+
+.border-xs-right {
+    border-width: 0;
+    border-color: #dee2e6;
+    border-style: solid;
+    border-right-width: 1px !important;
+}
+
+.border-xs-bottom-0 {
+    border-bottom: 0 !important;
+}
+
+.border-xs-bottom {
+    border-width: 0;
+    border-color: #dee2e6;
+    border-style: solid;
+    border-bottom-width: 1px !important;
+}
+
+.border-xs-left-0 {
+    border-left: 0 !important;
+}
+
+.border-xs-left {
+    border-width: 0;
+    border-color: #dee2e6;
+    border-style: solid;
+    border-left-width: 1px !important;
+}
+
+@media (min-width: 480px) {
+    .border-sm-0 {
+        border: 0 !important;
+    }
+    .border-sm {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-width: 1px !important;
+    }
+    .border-sm-top-0 {
+        border-top: 0 !important;
+    }
+    .border-sm-top {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-top-width: 1px !important;
+    }
+    .border-sm-right-0 {
+        border-right: 0 !important;
+    }
+    .border-sm-right {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-right-width: 1px !important;
+    }
+    .border-sm-bottom-0 {
+        border-bottom: 0 !important;
+    }
+    .border-sm-bottom {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-bottom-width: 1px !important;
+    }
+    .border-sm-left-0 {
+        border-left: 0 !important;
+    }
+    .border-sm-left {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-left-width: 1px !important;
+    }
+}
+
+@media (min-width: 720px) {
+    .border-md-0 {
+        border: 0 !important;
+    }
+    .border-md {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-width: 1px !important;
+    }
+    .border-md-top-0 {
+        border-top: 0 !important;
+    }
+    .border-md-top {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-top-width: 1px !important;
+    }
+    .border-md-right-0 {
+        border-right: 0 !important;
+    }
+    .border-md-right {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-right-width: 1px !important;
+    }
+    .border-md-bottom-0 {
+        border-bottom: 0 !important;
+    }
+    .border-md-bottom {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-bottom-width: 1px !important;
+    }
+    .border-md-left-0 {
+        border-left: 0 !important;
+    }
+    .border-md-left {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-left-width: 1px !important;
+    }
+}
+
+@media (min-width: 960px) {
+    .border-lg-0 {
+        border: 0 !important;
+    }
+    .border-lg {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-width: 1px !important;
+    }
+    .border-lg-top-0 {
+        border-top: 0 !important;
+    }
+    .border-lg-top {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-top-width: 1px !important;
+    }
+    .border-lg-right-0 {
+        border-right: 0 !important;
+    }
+    .border-lg-right {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-right-width: 1px !important;
+    }
+    .border-lg-bottom-0 {
+        border-bottom: 0 !important;
+    }
+    .border-lg-bottom {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-bottom-width: 1px !important;
+    }
+    .border-lg-left-0 {
+        border-left: 0 !important;
+    }
+    .border-lg-left {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-left-width: 1px !important;
+    }
+}
+
+@media (min-width: 1200px) {
+    .border-xl-0 {
+        border: 0 !important;
+    }
+    .border-xl {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-width: 1px !important;
+    }
+    .border-xl-top-0 {
+        border-top: 0 !important;
+    }
+    .border-xl-top {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-top-width: 1px !important;
+    }
+    .border-xl-right-0 {
+        border-right: 0 !important;
+    }
+    .border-xl-right {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-right-width: 1px !important;
+    }
+    .border-xl-bottom-0 {
+        border-bottom: 0 !important;
+    }
+    .border-xl-bottom {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-bottom-width: 1px !important;
+    }
+    .border-xl-left-0 {
+        border-left: 0 !important;
+    }
+    .border-xl-left {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-left-width: 1px !important;
+    }
+}
+
+@media (min-width: 1440px) {
+    .border-xxl-0 {
+        border: 0 !important;
+    }
+    .border-xxl {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-width: 1px !important;
+    }
+    .border-xxl-top-0 {
+        border-top: 0 !important;
+    }
+    .border-xxl-top {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-top-width: 1px !important;
+    }
+    .border-xxl-right-0 {
+        border-right: 0 !important;
+    }
+    .border-xxl-right {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-right-width: 1px !important;
+    }
+    .border-xxl-bottom-0 {
+        border-bottom: 0 !important;
+    }
+    .border-xxl-bottom {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-bottom-width: 1px !important;
+    }
+    .border-xxl-left-0 {
+        border-left: 0 !important;
+    }
+    .border-xxl-left {
+        border-width: 0;
+        border-color: #dee2e6;
+        border-style: solid;
+        border-left-width: 1px !important;
+    }
+}
+
+.opacity-10 {
+    opacity: 0.10;
+}
+
+.opacity-20 {
+    opacity: 0.20;
+}
+
+.opacity-30 {
+    opacity: 0.30;
+}
+
+.opacity-40 {
+    opacity: 0.40;
+}
+
+.opacity-50, #global-header button[data-toggle="collapse"][aria-expanded="true"] {
+    opacity: 0.50;
+}
+
+.opacity-60 {
+    opacity: 0.60;
+}
+
+.opacity-70 {
+    opacity: 0.70;
+}
+
+.opacity-80 {
+    opacity: 0.80;
+}
+
+.opacity-90 {
+    opacity: 0.90;
+}
+
+.bg-opacity-black-25 {
+    background-color: rgba(0, 0, 0, 0.25);
+}
+
+.bg-opacity-black-50 {
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+.bg-opacity-black-75 {
+    background-color: rgba(0, 0, 0, 0.75);
+}
+
+.text-shadow {
+    text-shadow: 0 0 6px #0a1438;
+}
+
+.text-shadow-border {
+    text-shadow: 0 0 1px black;
+}
+
+.no-btn-style {
+    color: currentColor;
+    font-weight: inherit;
+    border-color: transparent;
+    background-color: transparent;
+    padding: 0;
+    cursor: pointer;
+}
+
+.has-icon.disperse, .wrap-file-input .file-input-label .disperse.file-choose {
+    display: flex;
+    width: 100%;
+    flex-direction: row-reverse;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.has-icon:not(.disperse) span.title, .wrap-file-input .file-input-label .file-choose:not(.disperse) span.title {
+    margin-left: 0.5em;
+}
+
+ul.paragraph-li li,
+ol.paragraph-li li {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+}
+
+.z-index-100,
+.z-index-200,
+.z-index-300,
+.z-index-400,
+.z-index-500,
+.z-index-600,
+.z-index-700,
+.z-index-800,
+.z-index-900 {
+    position: relative;
+}
+
+.z-index-100 {
+    z-index: 100;
+}
+
+.z-index-200 {
+    z-index: 200;
+}
+
+.z-index-300 {
+    z-index: 300;
+}
+
+.z-index-400 {
+    z-index: 400;
+}
+
+.z-index-500 {
+    z-index: 500;
+}
+
+.z-index-600 {
+    z-index: 600;
+}
+
+.z-index-700 {
+    z-index: 700;
+}
+
+.z-index-800 {
+    z-index: 800;
+}
+
+.z-index-900 {
+    z-index: 900;
+}
+
+/*
+
+In this file:
+
+// A. Citywide header and footer
+// B. Local header and primary nav
+// C. Skip Menu
+// D. Forms
+// E. Gradients
+// F. Featured panels
+// G. Banner with background
+// H. Extensible lists
+// I. Matrix rows
+// J. Accordion and button toggle
+// K. Tabs
+// L. Cards
+// M. Tables
+
+*/
+@media (min-width: 960px) {
+    [id="languages"] ul li {
+        flex-basis: 20%;
+    }
+}
+
+#global-header {
+    background-color: white;
+}
+
+#global-header .btn,
+#global-header .input,
+#global-header .nav-link,
+#global-header .dropdown-menu,
+#global-header .form-control {
+    border-radius: 0;
+}
+
+#global-header button[data-toggle="collapse"] {
+    color: #212529;
+}
+
+#global-header .nav-link,
+#global-header .dropdown-menu a {
+    color: #212529;
+}
+
+#global-header [class*="border-"] {
+    border-color: #dee2e6 !important;
+}
+
+#global-header button[data-toggle="collapse"][aria-expanded="true"] {
+    transition: all 0.2s ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    #global-header button[data-toggle="collapse"][aria-expanded="true"] {
+        transition: none;
+    }
+}
+
+#global-header .nav-link {
+    font-weight: 700;
+}
+
+#global-header .nav-link.active {
+    text-decoration: underline;
+    color: #3B6CF6;
+}
+
+#global-header .nav-pills {
+    border-left: 1px solid #dee2e6;
+}
+
+#global-header .nav-pills .nav-item {
+    border-right: 1px solid #dee2e6;
+}
+
+@media (min-width: 960px) {
+    #global-header .nav-pills .nav-item {
+        flex: 1;
+    }
+}
+
+#global-header .nav-pills .nav-link {
+    background: transparent;
+}
+
+#global-header .nav-pills .nav-link.active {
+    text-decoration: underline;
+    color: #3B6CF6;
+}
+
+#global-header .dropdown-menu {
+    border: none;
+    padding: 0.75rem 1rem;
+}
+
+#global-header .nav:not(.nav-pills) .dropdown-menu {
+    margin: 0;
+}
+
+#global-header .nav-pills .dropdown-menu {
+    width: 100%;
+    left: 0;
+    margin: 0;
+    transform: none !important;
+    top: 100% !important;
+}
+
+#global-header .nav:not(.nav-pills) .nav-item-search {
+    border: 1px solid #dee2e6;
+}
+
+#global-header .nav-item-search {
+    position: relative;
+}
+
+#global-header .nav-item-search form,
+#global-header .nav-item-search input {
+    width: 100%;
+}
+
+#global-header .nav-item-search form {
+    display: flex;
+    height: 100%;
+    position: relative;
+}
+
+#global-header .nav-item-search button {
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+    width: 28px;
+}
+
+#global-header .nav-item-search input {
+    align-self: stretch;
+    font-size: 1rem;
+    border: 0;
+    padding-top: 0.75rem;
+    padding-right: calc(28px + 1rem);
+    padding-bottom: 0.75rem;
+    padding-left: 1rem;
+}
+
+@media (max-width: 959.98px) {
+    #global-header .nav-item {
+        border-top: 1px solid #dee2e6;
+        width: 100%;
+    }
+    #global-header .nav-item.nav-link {
+        text-align: left;
+    }
+    #global-header .nav-item,
+    #global-header .dropdown-menu {
+        background: none;
+    }
+    #global-header .dropdown-toggle {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+    #global-header .dropdown-toggle[aria-expanded="true"]::after {
+        border-top: 0;
+        border-right: 0.3em solid transparent;
+        border-bottom: 0.3em solid;
+        border-left: 0.3em solid transparent;
+    }
+    #global-header .dropdown-menu {
+        position: static !important;
+        width: 100%;
+        -webkit-transform: none !important;
+        transform: none !important;
+    }
+    #global-header .nav:not(.nav-pills) .dropdown-menu {
+        margin: 0;
+        box-shadow: none !important;
+    }
+}
+
+/* #global-header */
+.skip-menu {
+    top: 1rem;
+    left: 1rem;
+    z-index: 900;
+    padding: 1rem;
+    font-size: 1rem;
+    background: #e6ecf7;
+    color: #212529;
+}
+
+.skip-menu:hover {
+    color: currentColor;
+}
+
+.alert {
+    outline: 0;
+}
+
+.alert[tabindex="-1"]:focus {
+    box-shadow: 0 0 0 0.15rem #ea172b;
+}
+
+.alert-heading {
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+}
+
+.alert-text {
+    font-size: 1rem;
+}
+
+.form-group .invalid-feedback {
+    display: none;
+    margin-bottom: 0.5rem;
+}
+
+.form-group .invalid-description {
+    font-weight: 700;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+}
+
+.form-group.is-invalid label,
+.form-group.is-invalid .label {
+    color: #ea172b;
+}
+
+.form-group.is-invalid .invalid-feedback {
+    display: block;
+}
+
+.form-group.is-invalid .form-control:invalid:focus {
+    box-shadow: 0 0 0 0.15rem #ea172b;
+}
+
+fieldset,
+.fieldset {
+    border: 1px solid #dee2e6;
+    margin-bottom: 4rem;
+}
+
+legend,
+.legend {
+    font-size: 1rem;
+    font-weight: 400;
+    background: #181A7B;
+    color: white;
+    padding: 1rem;
+    margin-bottom: 0;
+}
+
+.wrap-file-input {
+    position: relative;
+}
+
+.wrap-file-input input[type="file"]:focus + label {
+    transition: all 0.2s ease-in-out;
+    border-color: #0029F7;
+    box-shadow: 0 0 0 2px rgba(0, 41, 247, 0.75);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .wrap-file-input input[type="file"]:focus + label {
+        transition: none;
+    }
+}
+
+.wrap-file-input .file-input-label {
+    border: 1px solid #777677;
+    display: block;
+}
+
+.wrap-file-input .file-input-label:hover .file-choose,
+.wrap-file-input .file-input-label:hover .file-name {
+    text-decoration: none;
+}
+
+.wrap-file-input .file-input-label .file-choose,
+.wrap-file-input .file-input-label .file-name {
+    width: 100%;
+    text-align: center;
+}
+
+.wrap-file-input .file-input-label .file-name {
+    padding: 0.5rem;
+    display: block;
+    white-space: normal;
+}
+
+@media (max-width: 959.98px) {
+    .wrap-file-input .file-choose,
+    .wrap-file-input .file-name {
+        display: block !important;
+    }
+}
+
+[class*="overlay-gradient-"] {
+    position: relative;
+    overflow: hidden;
+}
+
+[class*="overlay-gradient-"]::before {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: -1px;
+    right: -1px;
+    bottom: -1px;
+}
+
+.overlay-gradient-y-black::before {
+    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.9) 100%);
+}
+
+.overlay-gradient-x-white::before {
+    background-image: linear-gradient(to left, rgba(255, 255, 255, 0) 0%, white 100%);
+}
+
+.overlay-gradient-x-primary::before {
+    background-image: linear-gradient(to left, rgba(24, 26, 123, 0) 0, rgba(24, 26, 123, 0.8) 100%);
+}
+
+.overlay-gradient-x-info::before {
+    background-image: linear-gradient(to right, rgba(165, 19, 182, 0) 0, rgba(165, 19, 182, 0.75) 100%);
+}
+
+.featured-panel > .card,
+.featured-panel .card-img {
+    border: none;
+    border-radius: 0;
+}
+
+.featured-panel .card-img-overlay {
+    padding: 0;
+}
+
+@media (max-width: 479.98px) {
+    .featured-panel.device-sm .card-img-overlay {
+        position: relative;
+    }
+    .featured-panel.device-sm img.full-opacity-on-device {
+        opacity: 1;
+    }
+    .featured-panel.device-sm [class*="overlay-gradient"]::before {
+        display: none;
+    }
+    .featured-panel.device-sm [class*="border"] {
+        border: none !important;
+    }
+    .featured-panel.device-sm [class*="shadow"] {
+        box-shadow: none !important;
+    }
+    .featured-panel.device-sm [class*="text-shadow"] {
+        text-shadow: none;
+    }
+}
+
+@media (max-width: 719.98px) {
+    .featured-panel.device-md .card-img-overlay {
+        position: relative;
+    }
+    .featured-panel.device-md img.full-opacity-on-device {
+        opacity: 1;
+    }
+    .featured-panel.device-md [class*="overlay-gradient"]::before {
+        display: none;
+    }
+    .featured-panel.device-md [class*="border"] {
+        border: none !important;
+    }
+    .featured-panel.device-md [class*="shadow"] {
+        box-shadow: none !important;
+    }
+    .featured-panel.device-md [class*="text-shadow"] {
+        text-shadow: none;
+    }
+}
+
+@media (max-width: 959.98px) {
+    .featured-panel.device-lg .card-img-overlay {
+        position: relative;
+    }
+    .featured-panel.device-lg img.full-opacity-on-device {
+        opacity: 1;
+    }
+    .featured-panel.device-lg [class*="overlay-gradient"]::before {
+        display: none;
+    }
+    .featured-panel.device-lg [class*="border"] {
+        border: none !important;
+    }
+    .featured-panel.device-lg [class*="shadow"] {
+        box-shadow: none !important;
+    }
+    .featured-panel.device-lg [class*="text-shadow"] {
+        text-shadow: none;
+    }
+}
+
+@media (max-width: 1199.98px) {
+    .featured-panel.device-xl .card-img-overlay {
+        position: relative;
+    }
+    .featured-panel.device-xl img.full-opacity-on-device {
+        opacity: 1;
+    }
+    .featured-panel.device-xl [class*="overlay-gradient"]::before {
+        display: none;
+    }
+    .featured-panel.device-xl [class*="border"] {
+        border: none !important;
+    }
+    .featured-panel.device-xl [class*="shadow"] {
+        box-shadow: none !important;
+    }
+    .featured-panel.device-xl [class*="text-shadow"] {
+        text-shadow: none;
+    }
+}
+
+@media (max-width: 1439.98px) {
+    .featured-panel.device-xxl .card-img-overlay {
+        position: relative;
+    }
+    .featured-panel.device-xxl img.full-opacity-on-device {
+        opacity: 1;
+    }
+    .featured-panel.device-xxl [class*="overlay-gradient"]::before {
+        display: none;
+    }
+    .featured-panel.device-xxl [class*="border"] {
+        border: none !important;
+    }
+    .featured-panel.device-xxl [class*="shadow"] {
+        box-shadow: none !important;
+    }
+    .featured-panel.device-xxl [class*="text-shadow"] {
+        text-shadow: none;
+    }
+}
+
+.banner-with-background {
+    position: relative;
+    overflow: hidden;
+    min-height: 350px;
+}
+
+.banner-with-background > * {
+    position: relative;
+    z-index: auto;
+}
+
+.banner-with-background::before {
+    content: "";
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: auto;
+    opacity: 0.25;
+    background-image: url("../images/placeholder-1500x750.jpg");
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center center;
+}
+
+.banner-with-background.oculus::before {
+    background-image: url("../images/oculus.jpg");
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center center;
+}
+
+@media (max-width: 959.98px) {
+    .banner-with-background {
+        min-height: calc(350px * 0.75);
+    }
+}
+
+.extensible-list, [id="languages"] ul {
+    padding-left: 0;
+    list-style: none;
+    margin-bottom: 0;
+    -webkit-padding-start: 0;
+}
+
+.extensible-list li ul, [id="languages"] ul li ul {
+    margin-top: 0.5em;
+    padding-left: 1rem !important;
+    padding-right: 1rem !important;
+}
+
+.extensible-list li, [id="languages"] ul li {
+    margin-bottom: 0.5em;
+}
+
+.extensible-list li:last-child, [id="languages"] ul li:last-child {
+    margin-bottom: 0;
+}
+
+.extensible-list.horizontal, [id="languages"] ul.horizontal {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-left: -0.5em;
+    margin-right: -0.5em;
+}
+
+.extensible-list.horizontal li, [id="languages"] ul.horizontal li {
+    margin-bottom: 0;
+    margin-left: 0.5em;
+    margin-right: 0.5em;
+}
+
+@media (max-width: 479.98px) {
+    .extensible-list.horizontal.device-sm, [id="languages"] ul.horizontal.device-sm {
+        display: block !important;
+        margin-right: 0;
+        margin-left: 0;
+        padding-right: 0;
+        padding-left: 0;
+    }
+    .extensible-list.horizontal.device-sm li, [id="languages"] ul.horizontal.device-sm li {
+        margin-bottom: 0.5em;
+        display: block !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
+    .extensible-list.horizontal.device-sm li:last-child, [id="languages"] ul.horizontal.device-sm li:last-child {
+        margin-bottom: 0;
+    }
+}
+
+@media (max-width: 719.98px) {
+    .extensible-list.horizontal.device-md, [id="languages"] ul.horizontal.device-md {
+        display: block !important;
+        margin-right: 0;
+        margin-left: 0;
+        padding-right: 0;
+        padding-left: 0;
+    }
+    .extensible-list.horizontal.device-md li, [id="languages"] ul.horizontal.device-md li {
+        margin-bottom: 0.5em;
+        display: block !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
+    .extensible-list.horizontal.device-md li:last-child, [id="languages"] ul.horizontal.device-md li:last-child {
+        margin-bottom: 0;
+    }
+}
+
+@media (max-width: 959.98px) {
+    .extensible-list.horizontal.device-lg, [id="languages"] ul.horizontal.device-lg {
+        display: block !important;
+        margin-right: 0;
+        margin-left: 0;
+        padding-right: 0;
+        padding-left: 0;
+    }
+    .extensible-list.horizontal.device-lg li, [id="languages"] ul.horizontal.device-lg li {
+        margin-bottom: 0.5em;
+        display: block !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
+    .extensible-list.horizontal.device-lg li:last-child, [id="languages"] ul.horizontal.device-lg li:last-child {
+        margin-bottom: 0;
+    }
+}
+
+@media (max-width: 1199.98px) {
+    .extensible-list.horizontal.device-xl, [id="languages"] ul.horizontal.device-xl {
+        display: block !important;
+        margin-right: 0;
+        margin-left: 0;
+        padding-right: 0;
+        padding-left: 0;
+    }
+    .extensible-list.horizontal.device-xl li, [id="languages"] ul.horizontal.device-xl li {
+        margin-bottom: 0.5em;
+        display: block !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
+    .extensible-list.horizontal.device-xl li:last-child, [id="languages"] ul.horizontal.device-xl li:last-child {
+        margin-bottom: 0;
+    }
+}
+
+@media (max-width: 1439.98px) {
+    .extensible-list.horizontal.device-xxl, [id="languages"] ul.horizontal.device-xxl {
+        display: block !important;
+        margin-right: 0;
+        margin-left: 0;
+        padding-right: 0;
+        padding-left: 0;
+    }
+    .extensible-list.horizontal.device-xxl li, [id="languages"] ul.horizontal.device-xxl li {
+        margin-bottom: 0.5em;
+        display: block !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
+    .extensible-list.horizontal.device-xxl li:last-child, [id="languages"] ul.horizontal.device-xxl li:last-child {
+        margin-bottom: 0;
+    }
+}
+
+.matrix-border {
+    margin-top: -0.5px;
+    margin-right: -0.5px;
+    margin-bottom: -0.5px;
+    margin-left: -0.5px;
+}
+
+.matrix-border > [class^="col"] {
+    padding: 0.5px;
+}
+
+.matrix-gutter {
+    margin-top: -0.5rem;
+    margin-right: -0.5rem;
+    margin-bottom: -0.5rem;
+    margin-left: -0.5rem;
+}
+
+.matrix-gutter > [class^="col"] {
+    padding: 0.5rem;
+}
+
+.btn-toggle [data-toggle="collapse"]::after, .accordion-group a[data-toggle="collapse"]:after {
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
+    font-size: inherit;
+    font-style: normal;
+    font-variant: normal;
+    text-rendering: auto;
+    color: currentColor;
+}
+
+.btn-toggle [data-toggle="collapse"],
+.accordion-group [data-toggle="collapse"] {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.btn-toggle [data-toggle="collapse"]::after,
+.accordion-group [data-toggle="collapse"]::after {
+    margin-left: 1rem;
+}
+
+.btn-toggle [data-toggle="collapse"] {
+    overflow: hidden;
+}
+
+.btn-toggle [data-toggle="collapse"]::after {
+    content: "\f067";
+}
+
+.btn-toggle [data-toggle="collapse"][aria-expanded="true"]::after {
+    content: "\f068";
+}
+
+.btn-toggle [data-toggle="collapse"][aria-expanded="false"]::after {
+    content: "\f067";
+}
+
+.accordion-group .card,
+.accordion-group .card-header {
+    border: 0;
+    border-radius: 0;
+}
+
+.accordion-group .card {
+    background-color: #e6ecf7;
+    margin-bottom: 0.5rem;
+}
+
+.accordion-group .card:last-child {
+    margin-bottom: 0;
+}
+
+.accordion-group a[data-toggle="collapse"] {
+    color: #181A7B;
+}
+
+.accordion-group a[data-toggle="collapse"]:after {
+    content: "\f067";
+}
+
+.accordion-group a[data-toggle="collapse"][aria-expanded="true"]:after {
+    content: "\f106";
+}
+
+.accordion-group a[data-toggle="collapse"][aria-expanded="false"]:after {
+    content: "\f107";
+}
+
+.nav-pills .nav-link,
+.nav-tabs .nav-link {
+    color: #212529;
+}
+
+.nav-pills .nav-link.active,
+.nav-tabs .nav-link.active {
+    text-decoration: underline;
+}
+
+.nav-pills .nav-item,
+.nav-tabs .nav-item {
+    text-align: center;
+}
+
+@media (max-width: 479.98px) {
+    .nav-pills.device-sm,
+    .nav-tabs.device-sm {
+        flex-direction: column;
+        border-color: transparent;
+        margin-bottom: 1rem;
+    }
+    .nav-pills.device-sm .nav-item,
+    .nav-tabs.device-sm .nav-item {
+        text-align: center;
+        border-color: #dee2e6;
+    }
+}
+
+@media (max-width: 719.98px) {
+    .nav-pills.device-md,
+    .nav-tabs.device-md {
+        flex-direction: column;
+        border-color: transparent;
+        margin-bottom: 1rem;
+    }
+    .nav-pills.device-md .nav-item,
+    .nav-tabs.device-md .nav-item {
+        text-align: center;
+        border-color: #dee2e6;
+    }
+}
+
+@media (max-width: 959.98px) {
+    .nav-pills.device-lg,
+    .nav-tabs.device-lg {
+        flex-direction: column;
+        border-color: transparent;
+        margin-bottom: 1rem;
+    }
+    .nav-pills.device-lg .nav-item,
+    .nav-tabs.device-lg .nav-item {
+        text-align: center;
+        border-color: #dee2e6;
+    }
+}
+
+@media (max-width: 1199.98px) {
+    .nav-pills.device-xl,
+    .nav-tabs.device-xl {
+        flex-direction: column;
+        border-color: transparent;
+        margin-bottom: 1rem;
+    }
+    .nav-pills.device-xl .nav-item,
+    .nav-tabs.device-xl .nav-item {
+        text-align: center;
+        border-color: #dee2e6;
+    }
+}
+
+@media (max-width: 1439.98px) {
+    .nav-pills.device-xxl,
+    .nav-tabs.device-xxl {
+        flex-direction: column;
+        border-color: transparent;
+        margin-bottom: 1rem;
+    }
+    .nav-pills.device-xxl .nav-item,
+    .nav-tabs.device-xxl .nav-item {
+        text-align: center;
+        border-color: #dee2e6;
+    }
+}
+
+.nav-tabs .nav-item.active {
+    font-weight: 700;
+    color: #A513B6;
+}
+
+.card,
+.card-header,
+.card-footer {
+    border: none;
+}
+
+.card-header,
+.card-footer {
+    background-color: transparent;
+}
+
+table {
+    font-size: 1rem;
+}
+
+table th {
+    color: #A513B6;
+}
+
+table.table-stack-on-mobile thead td:empty {
+    border: none;
+}
+
+@media (min-width: 960px) {
+    table.table-stack-on-mobile .psuedo-cell {
+        display: none;
+    }
+}
+
+@media (max-width: 959.98px) {
+    table.table-stack-on-mobile thead {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+    table.table-stack-on-mobile tbody tr {
+        display: flex;
+        flex-flow: row wrap;
+        border-top: 1px solid #A513B6;
+    }
+    table.table-stack-on-mobile tbody tr + tr {
+        margin-top: 2rem;
+    }
+    table.table-stack-on-mobile td {
+        display: flex;
+        align-items: center;
+        word-break: break-all;
+        hyphens: auto;
+    }
+    table.table-stack-on-mobile td[aria-hidden="true"] {
+        flex-basis: 100%;
+    }
+    table.table-stack-on-mobile td:not([aria-hidden="true"]) {
+        flex-basis: 100%;
+        padding-top: 0;
+        border-top: none;
+    }
+    table.table-stack-on-mobile td:nth-of-type(2), table.table-stack-on-mobile td:first-of-type {
+        border: none;
+    }
+    table.table-stack-on-mobile th {
+        flex-basis: 100%;
+        border-bottom: 1px solid #dee2e6;
+        border-width: 0 0 1px 0;
+        font-size: 1.25em;
+    }
+}
+
+/*
+
+In this file:
+
+// A. Floating breakpoints bar
+// B. Container background color
+
+*/
+[class*="subway-icon"] {
+    position: relative;
+    font-size: .75em;
+    z-index: 5;
+    height: 1em;
+    width: 1em;
+    line-height: 1em;
+    margin-left: 0.2em;
+    margin-right: 0.2em;
+    justify-content: center;
+    align-items: center;
+    display: inline-flex;
+    text-align: center;
+    font-weight: bold;
+    text-transform: uppercase;
+    color: #000;
+}
+
+[class*="subway-icon"]::before {
+    content: "";
+    position: absolute;
+    z-index: -1;
+    width: calc(100% + 0.4em);
+    height: calc(100% + 0.4em);
+    left: -0.2em;
+    top: -0.2em;
+    border-radius: 50%;
+    background-color: red;
+}
+
+[class*="subway-icon"].express {
+    margin-left: 0.2666666667em;
+    margin-right: 0.2666666667em;
+}
+
+[class*="subway-icon"].express::before {
+    transform: rotate(45deg);
+    border-radius: 0;
+    width: calc(100% + 0.1em);
+    height: calc(100% + 0.1em);
+    left: -0.05em;
+    top: -0.05em;
+}
+
+.mta-red {
+    color: #fff;
+}
+
+.mta-red::before {
+    background-color: #df0000;
+}
+
+.mta-green {
+    color: #fff;
+}
+
+.mta-green::before {
+    background-color: #008700;
+}
+
+.mta-blue {
+    color: #fff;
+}
+
+.mta-blue::before {
+    background-color: #0a5786;
+}
+
+.mta-orange {
+    color: #fff;
+}
+
+.mta-orange::before {
+    background-color: #de3700;
+}
+
+.mta-purple {
+    color: #fff;
+}
+
+.mta-purple::before {
+    background-color: #5a045a;
+}
+
+.mta-green-2 {
+    color: #fff;
+}
+
+.mta-green-2::before {
+    background-color: #4f8403;
+}
+
+.mta-yellow {
+    color: #000;
+}
+
+.mta-yellow::before {
+    background-color: #FCCC0A;
+}
+
+.mta-gray {
+    color: #fff;
+}
+
+.mta-gray::before {
+    background-color: #666;
+}
+
+.mta-brown {
+    color: #fff;
+}
+
+.mta-brown::before {
+    background-color: #573208;
+}
+
+.list-group.custom-active a.active {
+    background-color: unset;
+    font-weight: 700;
+    border-color: #dee2e6;
+    border-left-color: #A513B6;
+    border-left-width: 2px;
+    color: #A513B6;
+}


### PR DESCRIPTION
Changes made:
- Updated Gemfile for the public interface to use the latest Bootstrap 4 and Font Awesome gems
- Imported theme and custom stylesheets from nyc-core-framework