### PR TITLE
AB#571 - Collection Organization tab

### DIFF
--- a/public/app/assets/stylesheets/custom.scss
+++ b/public/app/assets/stylesheets/custom.scss
@@ -171,3 +171,59 @@ tr.waypoint {
 tr td {
     vertical-align: text-bottom !important;
 }
+
+//Collection organization tree
+.treeview, .treeview ul {
+    margin: 0;
+    padding:0;
+    list-style:none;
+    overflow:auto;
+}
+.treeview ul {
+    position:relative
+}
+.treeview ul ul {
+    margin-left:.5em !important;
+}
+.treeview ul:before {
+    content:"";
+    display:block;
+    width:0;
+    position:absolute;
+    top:0;
+    bottom:0;
+    left:0;
+}
+.treeview li {
+    padding:0 1em;
+    position:relative
+}
+.treeview ul li:before {
+    content:"";
+    display:block;
+    width:10px;
+    height:0;
+    margin-top:-1px;
+    position:absolute;
+    top:1em;
+    left:0
+}
+.treeview ul li:last-child:before {
+    height:auto;
+    top:1em;
+    bottom:0
+}
+.indicator {
+    margin-right:5px;
+}
+.treeview li button, .treeview li button:active, .treeview li button:focus {
+    text-decoration: none;
+    border:none;
+    margin:0px 0px 0px 0px;
+    padding:0px 0px 0px 0px;
+    outline: 0;
+}
+#root{
+    font-size: 12pt;
+}
+

--- a/public/config/routes.rb
+++ b/public/config/routes.rb
@@ -27,6 +27,10 @@ Rails.application.routes.draw do
     get  "repositories/:rid/resources/:id/tree/waypoint"  => 'resources#tree_waypoint'
     get  "repositories/:rid/resources/:id/tree/node"  => 'resources#tree_node'
     get  "repositories/:rid/resources/:id/tree/node_from_root"  => 'resources#tree_node_from_root'
+    #Fetches raw data for records and renders it as an infinite item
+    get  "repositories/:rid/resources/:id/tree/infinite_resolve"  => 'resources#infinite_resolve'
+    #Fetches raw data for a record
+    get "repositories/:rid/resources/:id/raw_json"  => 'resources#raw_json'
 
     #ACCESSIONS
     get "accessions/:slug_or_id"  => 'accessions#show'


### PR DESCRIPTION
-- Fixed sidebar indentation on collection pages
-- Removed "Collection Inventory" tab
-- Sidebar click adds all records from root to clicked element on the left panel
-- Clicking element on left panel redirects to individual record
-- Sidebar does not show file and item level records
-- Sidebar sticky 