### PR TITLE
AB#34 - NYC.ID Login

### DIFF
--- a/common/db/migrations/137_add_guid_to_user.rb
+++ b/common/db/migrations/137_add_guid_to_user.rb
@@ -1,0 +1,16 @@
+require_relative 'utils'
+
+Sequel.migration do
+  up do
+    $stderr.puts("Add guid to user table")
+    alter_table(:user) do
+      add_column(:guid, String)
+    end
+  end
+
+  down do
+    alter_table(:user) do
+      drop_column(:guid)
+    end
+  end
+end

--- a/common/schemas/user.rb
+++ b/common/schemas/user.rb
@@ -25,6 +25,7 @@
       },
 
       "email" => {"type" => "string", "maxLength" => 255},
+      "guid" => {"type" => "string", "maxLength" => 255},
       "first_name" => {"type" => "string", "maxLength" => 255},
       "last_name" => {"type" => "string", "maxLength" => 255},
       "telephone" => {"type" => "string", "maxLength" => 255},

--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -66,6 +66,11 @@ gem 'zip-zip', '0.3'
 
 gem 'nokogiri', '>= 1.10.8'
 
+gem 'omniauth',      '1.7.1'
+gem 'omniauth-cas',  '1.1.1'
+gem 'omniauth-saml', '1.8.1'
+gem 'httparty'
+
 require 'asutils'
 
 # Allow plugins to provide their own Gemfiles too.

--- a/plugins/aspace-oauth/.gitignore
+++ b/plugins/aspace-oauth/.gitignore
@@ -1,0 +1,4 @@
+*.swp
+.bundle/
+Gemfile.lock
+vendor/

--- a/plugins/aspace-oauth/Gemfile
+++ b/plugins/aspace-oauth/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+ASpaceGems.setup if defined? ASpaceGems
+source 'https://rubygems.org'
+
+gem 'omniauth',      '1.7.1'
+gem 'omniauth-cas',  '1.1.1'
+gem 'omniauth-saml', '1.8.1'
+gem 'httparty'

--- a/plugins/aspace-oauth/README.md
+++ b/plugins/aspace-oauth/README.md
@@ -1,0 +1,149 @@
+# ArchivesSpace Oauth
+
+Configure ArchivesSpace as a service provider (SP) for oauth authentication.
+*The plugin delegates authentication to the configured identity provider (IDP).*
+
+Strategies tested:
+
+- [CAS](https://github.com/dlindahl/omniauth-cas)
+- Developer [built-in for testing]
+- [SAML](https://github.com/omniauth/omniauth-saml)
+
+## Overview
+
+Enabling this plugin will:
+
+- Provide Identity Provider (IDP) Sign In link/s
+- The link will redirect the user to the IDP login portal
+- If successful the user will have a user record created in ArchivesSpace
+- User group membership and permissions are handled within ArchivesSpace
+- The oauth plugin handles (by delegating) authentication only
+
+## Installation
+
+Download this plugin to `$ARCHIVESSPACE_DIR/plugins` and initialize it:
+
+```bash
+cd /path/to/archivesspace/plugins
+# with wget and unzip
+wget https://github.com/lyrasis/aspace-oauth/archive/master.zip
+unzip master.zip
+mv aspace-oauth-master aspace-oauth
+
+# or with git
+git clone https://github.com/lyrasis/aspace-oauth.git
+
+# now download the gems
+cd /path/to/archivesspace
+./scripts/initialize-plugin.sh aspace-oauth
+```
+
+## Configuration
+
+```ruby
+# example for testing from src: developer, saml
+AppConfig[:authentication_sources] = [
+  {
+    model: 'ASOauth',
+    provider: 'developer',
+    label: 'Sign In Developer',
+    slo_link: false,
+    config: {},
+  },
+  {
+    model: 'ASOauth',
+    provider: 'saml',
+    label: 'Institutional Sign In',
+    slo_link: false,
+    # METADATA URL: optional, use to download configuration
+    # metadata_parser_url: "https://login.somewhere.edu:4443/idp/shibboleth",
+    config: {
+      :assertion_consumer_service_url     => "http://localhost:3000/auth/saml/callback",
+      :issuer                             => "http://localhost:3000/auth/saml/metadata",
+      :name_identifier_format             => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+      # THESE ARE OPTIONAL IF USING METADATA URL (but can be used to override parsed metadata)
+      :idp_sso_target_url                 => "http://localhost/simplesaml/saml2/idp/SSOService.php",
+      :idp_cert_fingerprint               => "119b9e027959cdb7c662cfd075d9e2ef384e445f",
+      :idp_cert_fingerprint_validator     => lambda { |fingerprint| fingerprint },
+      # OPTIONAL: for encrypted assertions
+      :certificate                        => "PUBLIC CERT",
+      :private_key                        => "PRIVATE KEY",
+      # OPTIONAL: may be required by IDP (used with certificate and private_key)
+      :security                           => {
+        authn_requests_signed:     true,
+        want_assertions_signed:    true,
+        want_assertions_encrypted: true,
+        metadata_signed:           true,
+        # XMLSecurity::Document strings for digest and signature will be resolved to constant
+        digest_method:             "XMLSecurity::Document::SHA256",
+        signature_method:          "XMLSecurity::Document::RSA_SHA256",
+        embed_sign:                true,
+      },
+      :attribute_statements => {
+        email: ["urn:oid:0.9.2342.19200300.100.1.3"],
+      },
+    }
+  },
+  {
+    model: 'ASOauth',
+    provider: 'cas',
+    label: 'CAS Sign In',
+    slo_link: true,
+    config: {
+      url: 'https://login.ivory-tower.edu',
+      host: 'login.ivory-tower.edu',
+      ssl: true,
+      login_url: '/cas/login',
+      logout_url: '/cas/logout',
+      service_validate_url: '/cas/serviceValidate',
+      uid_key: 'user',
+      email_key: 'email'
+      # more cas keys and options at: https://github.com/dlindahl/omniauth-cas
+      #
+      # if your server does not return an email address, you can add one
+      # here using the fetch_raw_info option.
+      fetch_raw_info: ->(s, o, t, user_info) {  { email: "#{user_info['user']}@ivory-tower.edu" } }
+    }
+  }
+]
+
+# add the plugin to the list
+AppConfig[:plugins] << "aspace-oauth"
+```
+
+Add / change providers as needed and refer to the project documentation
+for configuration details. There are many more configuration options than shown
+above.
+
+For testing SAML there is a helpful docker image:
+
+```bash
+docker run --name=test-saml-idp -d \
+  --net=host \
+  -e SIMPLESAMLPHP_SP_ENTITY_ID=http://localhost:3000 \
+  -e SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=http://localhost:3000/auth/saml/callback \
+  kristophjunge/test-saml-idp
+```
+
+The test SAML service will be available at: `http://localhost`.
+
+## SAML
+
+To generate a cert / key use a command like:
+
+```bash
+openssl genrsa -out rsaprivkey.pem 2048
+openssl req -new -x509 -key rsaprivkey.pem -out rsacert.pem
+```
+
+## Developer
+
+```bash
+./build/run bundler -Dgemfile=../plugins/aspace-oauth/Gemfile
+```
+
+## License
+
+This project is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+
+---

--- a/plugins/aspace-oauth/backend/model/asoauth.rb
+++ b/plugins/aspace-oauth/backend/model/asoauth.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class ASOauthException < StandardError
+end
+
+class ASOauth
+  include JSONModel
+
+  def initialize(definition)
+    @provider = definition[:provider]
+  end
+
+  def name
+    "ArchivesSpace Oauth - #{@provider}"
+  end
+
+  # For Oauth authentication has already happened
+  # via the frontend. As part of that process a
+  # file is written to the system tmpdir and the
+  # filename is provided as the "password".
+  # The file and contents are checked to verify the user.
+  def authenticate(username, password)
+    return nil unless password.start_with?("aspace-oauth-#{@provider}")
+
+    pw_path = File.join(Dir.tmpdir, password)
+    return nil unless File.exist? pw_path
+
+    info = JSON.parse(File.read(pw_path))['info']
+    return nil unless username == info['username']
+
+    JSONModel(:user).from_hash(
+      username: username,
+      name: info['name'],
+      email: info['email']
+    )
+  end
+
+  def matching_usernames(query)
+    DB.open do |db|
+      query = query.gsub(/[%]/, '').downcase
+      db[:user]
+        .filter(Sequel.~(is_system_user: 1))
+        .filter(Sequel.like(
+                  Sequel.function(:lower, :username), "#{query}%"
+                ))
+        .filter(Sequel.like(:source, name))
+        .select(:username)
+        .limit(AppConfig[:max_usernames_per_source].to_i)
+        .map { |row| row[:username] }
+    end
+  end
+end

--- a/plugins/aspace-oauth/frontend/controllers/oauth_controller.rb
+++ b/plugins/aspace-oauth/frontend/controllers/oauth_controller.rb
@@ -11,7 +11,7 @@ class OauthController < ApplicationController
   # the user for the backend and then deleted.
   def create
     saml_attrs = request.env['omniauth.auth'].extra.response_object.attributes
-    nycidwebservices = NYCIDWebServices.new
+    nycidwebservices = NYCID::NYCIDWebServices.new
 
     if saml_attrs[:nycExtEmailValidationFlag] == 'False'
       email_validation_status = nycidwebservices.check_email_validation_status(saml_attrs[:GUID])
@@ -41,7 +41,7 @@ class OauthController < ApplicationController
     uid = auth_hash.uid
     email = user_json["email"]
     username = user_json["email"]
-    guid = user_json["guid"]
+    guid = user_json["id"]
     puts "Received callback for: [uid: #{uid}], [email: #{email}]"
 
     if username && email
@@ -60,7 +60,7 @@ class OauthController < ApplicationController
     end
 
     File.delete pw_path if File.exist? pw_path
-    redirect_to controller: :welcome, action: :index
+    redirect_to controller: :welcome, action: :index, guid: guid
   end
 
   def failure
@@ -83,128 +83,4 @@ class OauthController < ApplicationController
   def auth_hash
     request.env['omniauth.auth']
   end
-end
-
-class NYCIDWebServices
-    # Validate a user's email address
-    EMAIL_VALIDATION_ENDPOINT = '/account/validateEmail.htm'.freeze
-    # Check the validation status of the user's email address
-    EMAIL_VALIDATION_STATUS_ENDPOINT = '/account/api/isEmailValidated.htm'.freeze
-    # Search for a user by their guid or email addresss
-    USER_SEARCH_ENDPOINT = '/account/api/user.htm'.freeze
-    # Search for multiple users by their guids or their "Start Date"
-    USERS_SEARCH_ENDPOINT = '/account/api/getUsers.htm'.freeze
-    # Default HTTP Verb for API
-    DEFAULT_METHOD = 'GET'.freeze
-
-    def initialize(
-        service_account_username: AppConfig[:nyc_id_web_services_username],
-        service_account_password: AppConfig[:nyc_id_web_services_password],
-        api_uri: AppConfig[:nyc_id_web_services_url]
-    )
-      @service_account_username = service_account_username
-      @service_account_password = service_account_password
-      @api_uri = api_uri
-      @acs_url = AppConfig[:saml_acs]
-    end
-
-    # Checks the users email validation status using NYC.ID Web Services.
-    #
-    # Params:
-    # * +:guid+ - Unique identifier for the user from NYC.ID
-    #
-    # Returns:
-    # Boolean value of user's email validation status.
-    def check_email_validation_status(guid)
-      params = { guid: guid }
-      response = nycid_web_services_request(
-        EMAIL_VALIDATION_STATUS_ENDPOINT,
-        params,
-        method: DEFAULT_METHOD
-      )
-      response['validated']
-    end
-
-    # Validates the users email address using NYC.ID Web Services.
-    #
-    # Params:
-    # * +:email_address+ - User's email address.
-    #
-    # Returns:
-    # String of URL to request another validation email.
-    def validate_email(email_address)
-      if email_address.nil?
-        raise ArgumentError, 'You must provide an email_address'
-      end
-
-      "#{@api_uri}#{EMAIL_VALIDATION_ENDPOINT}?emailAddress=#{email_address}&target=#{@acs_url}"
-    end
-
-    # Retrieves a JSON-formatted user from the NYC.ID Web Services API.
-    #
-    # Params:
-    # * +:guid+ - User's unique identifier.
-    #
-    # Returns:
-    # JSON-formatted user as specified by NYC.ID (http://nyc4d.nycnet/nycid/search.shtml#json-formatted-users).
-    def search_user(guid)
-      nycid_web_services_request(
-        USER_SEARCH_ENDPOINT,
-        { guid: guid },
-        method: DEFAULT_METHOD
-      )
-    end
-
-    private
-
-    # Query the NYC.ID Web Services API.
-    #
-    # Params:
-    # * +:endpoint+ - Services endpoint being targeted.
-    # * +:params+ - Query parameters for the endpoint.
-    # * +:method+ - HTTP Verb being used in the API call. Defaults to "GET".
-    #
-    # Returns:
-    # HTTP Response from NYC.ID Web Services API Endpoint.
-    def nycid_web_services_request(endpoint, params, method: DEFAULT_METHOD)
-      Rails.logger.info "NYC Web Services Request: #{method} #{endpoint}"
-      Rails.logger.info "#{params}"
-      params[:userName] = @service_account_username
-      signature = generate_nycid_signature(endpoint, params, @service_account_password, method: method)
-      params[:signature] = signature
-
-      url = @api_uri + "#{endpoint}"
-      Rails.logger.info "#{url}"
-      response = HTTParty.get(url, query: params)
-      if response.code != 200
-        Rails.logger.error JSON.pretty_generate(response.parsed_response)
-      end
-
-      response.parsed_response
-    end
-
-    # Generate a signature for a request to the NYC.ID Web Services API.
-    #
-    # Params:
-    # * +:url_path+ - URL Path being accessed (without domain). See constants for valid values.
-    # * +:query_string+ - Query String in a hash of (key, value) pairs.
-    # * +:nycid_web_services_password+ - Password used to authenticate with NYC.ID Web Services.
-    # * +:method+ - HTTP Verb being used in the API call. Defaults to "GET".
-    #
-    # Returns:
-    # HMAC-SHA256 Signature for NYC.ID Web Services request.
-    def generate_nycid_signature(url_path, query_string, signing_key, method: DEFAULT_METHOD)
-      # endpoint must begin with a forward slash
-      url_path = "/#{url_path}" if url_path.first != '/'
-
-      # Sort the query string by keys
-      parameter_values = Hash[query_string.sort_by { |key, val| key.to_s }]
-
-      # Signature contains only the values of the sorted query string joined with no separator
-      signature_parameter_values = parameter_values.map { |key, val| "#{val}" }.join
-
-      value_to_sign = "#{method}#{url_path}#{signature_parameter_values}"
-
-      OpenSSL::HMAC.hexdigest('sha256', signing_key, value_to_sign)
-    end
 end

--- a/plugins/aspace-oauth/frontend/controllers/oauth_controller.rb
+++ b/plugins/aspace-oauth/frontend/controllers/oauth_controller.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+class OauthController < ApplicationController
+  skip_before_action :unauthorised_access
+  skip_before_action :verify_authenticity_token
+  include JSONModel
+
+  # IMPLEMENTS: /auth/:provider/callback
+  # Successful authentication populates the auth_hash with data
+  # that is written to the system tmpdir. This is used to verify
+  # the user for the backend and then deleted.
+  def create
+    saml_attrs = request.env['omniauth.auth'].extra.response_object.attributes
+    nycidwebservices = NYCIDWebServices.new
+
+    if saml_attrs[:nycExtEmailValidationFlag] == 'False'
+      email_validation_status = nycidwebservices.check_email_validation_status(saml_attrs[:GUID])
+      if email_validation_status == false
+        redirect_to nycidwebservices.validate_email(saml_attrs[:mail])
+        return
+      end
+    end
+
+    # Get the User Attributes from NYC.ID
+    user_json = nycidwebservices.search_user(saml_attrs[:GUID])
+
+    # Get the domain for the Users' email address
+    email_domain = user_json['email'].split('@').last
+
+    # Users whose email domain is in the approved list are not allowed to login
+    unless AppConfig[:approved_domains].include?(email_domain)
+      flash[:error] = 'Authentication error, unable to login. Your email address is not in the list approved domains.'
+      redirect_to controller: :welcome, action: :index
+      return
+    end
+
+    pw      = "aspace-oauth-#{auth_hash[:provider]}-#{SecureRandom.uuid}"
+    pw_path = File.join(Dir.tmpdir, pw)
+    backend_session = nil
+
+    uid = auth_hash.uid
+    email = user_json["email"]
+    username = user_json["email"]
+    guid = user_json["guid"]
+    puts "Received callback for: [uid: #{uid}], [email: #{email}]"
+
+    if username && email
+      username = username.split('@')[0] # usernames cannot be email addresses
+      auth_hash[:info][:username] = username # set username, checked in backend
+      auth_hash[:info][:email] = email # ensure email is set in info
+      File.open(pw_path, 'w') { |f| f.write(JSON.generate(auth_hash)) }
+      backend_session = User.login(username, pw)
+    end
+
+    if backend_session
+      User.establish_session(self, backend_session, username)
+      load_repository_list
+    else
+      flash[:error] = 'Authentication error, unable to login.'
+    end
+
+    File.delete pw_path if File.exist? pw_path
+    redirect_to controller: :welcome, action: :index
+  end
+
+  def failure
+    flash[:error] = params[:message]
+    redirect_to controller: :welcome, action: :index
+  end
+
+  def cas_logout
+    reset_session
+    redirect_to AspaceOauth.cas_logout_url
+  end
+
+  def saml_logout
+    reset_session
+    redirect_to AspaceOauth.saml_logout_url
+  end
+
+  protected
+
+  def auth_hash
+    request.env['omniauth.auth']
+  end
+end
+
+class NYCIDWebServices
+    # Validate a user's email address
+    EMAIL_VALIDATION_ENDPOINT = '/account/validateEmail.htm'.freeze
+    # Check the validation status of the user's email address
+    EMAIL_VALIDATION_STATUS_ENDPOINT = '/account/api/isEmailValidated.htm'.freeze
+    # Search for a user by their guid or email addresss
+    USER_SEARCH_ENDPOINT = '/account/api/user.htm'.freeze
+    # Search for multiple users by their guids or their "Start Date"
+    USERS_SEARCH_ENDPOINT = '/account/api/getUsers.htm'.freeze
+    # Default HTTP Verb for API
+    DEFAULT_METHOD = 'GET'.freeze
+
+    def initialize(
+        service_account_username: AppConfig[:nyc_id_web_services_username],
+        service_account_password: AppConfig[:nyc_id_web_services_password],
+        api_uri: AppConfig[:nyc_id_web_services_url]
+    )
+      @service_account_username = service_account_username
+      @service_account_password = service_account_password
+      @api_uri = api_uri
+      @acs_url = AppConfig[:saml_acs]
+    end
+
+    # Checks the users email validation status using NYC.ID Web Services.
+    #
+    # Params:
+    # * +:guid+ - Unique identifier for the user from NYC.ID
+    #
+    # Returns:
+    # Boolean value of user's email validation status.
+    def check_email_validation_status(guid)
+      params = { guid: guid }
+      response = nycid_web_services_request(
+        EMAIL_VALIDATION_STATUS_ENDPOINT,
+        params,
+        method: DEFAULT_METHOD
+      )
+      response['validated']
+    end
+
+    # Validates the users email address using NYC.ID Web Services.
+    #
+    # Params:
+    # * +:email_address+ - User's email address.
+    #
+    # Returns:
+    # String of URL to request another validation email.
+    def validate_email(email_address)
+      if email_address.nil?
+        raise ArgumentError, 'You must provide an email_address'
+      end
+
+      "#{@api_uri}#{EMAIL_VALIDATION_ENDPOINT}?emailAddress=#{email_address}&target=#{@acs_url}"
+    end
+
+    # Retrieves a JSON-formatted user from the NYC.ID Web Services API.
+    #
+    # Params:
+    # * +:guid+ - User's unique identifier.
+    #
+    # Returns:
+    # JSON-formatted user as specified by NYC.ID (http://nyc4d.nycnet/nycid/search.shtml#json-formatted-users).
+    def search_user(guid)
+      nycid_web_services_request(
+        USER_SEARCH_ENDPOINT,
+        { guid: guid },
+        method: DEFAULT_METHOD
+      )
+    end
+
+    private
+
+    # Query the NYC.ID Web Services API.
+    #
+    # Params:
+    # * +:endpoint+ - Services endpoint being targeted.
+    # * +:params+ - Query parameters for the endpoint.
+    # * +:method+ - HTTP Verb being used in the API call. Defaults to "GET".
+    #
+    # Returns:
+    # HTTP Response from NYC.ID Web Services API Endpoint.
+    def nycid_web_services_request(endpoint, params, method: DEFAULT_METHOD)
+      Rails.logger.info "NYC Web Services Request: #{method} #{endpoint}"
+      Rails.logger.info "#{params}"
+      params[:userName] = @service_account_username
+      signature = generate_nycid_signature(endpoint, params, @service_account_password, method: method)
+      params[:signature] = signature
+
+      url = @api_uri + "#{endpoint}"
+      Rails.logger.info "#{url}"
+      response = HTTParty.get(url, query: params)
+      if response.code != 200
+        Rails.logger.error JSON.pretty_generate(response.parsed_response)
+      end
+
+      response.parsed_response
+    end
+
+    # Generate a signature for a request to the NYC.ID Web Services API.
+    #
+    # Params:
+    # * +:url_path+ - URL Path being accessed (without domain). See constants for valid values.
+    # * +:query_string+ - Query String in a hash of (key, value) pairs.
+    # * +:nycid_web_services_password+ - Password used to authenticate with NYC.ID Web Services.
+    # * +:method+ - HTTP Verb being used in the API call. Defaults to "GET".
+    #
+    # Returns:
+    # HMAC-SHA256 Signature for NYC.ID Web Services request.
+    def generate_nycid_signature(url_path, query_string, signing_key, method: DEFAULT_METHOD)
+      # endpoint must begin with a forward slash
+      url_path = "/#{url_path}" if url_path.first != '/'
+
+      # Sort the query string by keys
+      parameter_values = Hash[query_string.sort_by { |key, val| key.to_s }]
+
+      # Signature contains only the values of the sorted query string joined with no separator
+      signature_parameter_values = parameter_values.map { |key, val| "#{val}" }.join
+
+      value_to_sign = "#{method}#{url_path}#{signature_parameter_values}"
+
+      OpenSSL::HMAC.hexdigest('sha256', signing_key, value_to_sign)
+    end
+end

--- a/plugins/aspace-oauth/frontend/lib/aspace_oauth.rb
+++ b/plugins/aspace-oauth/frontend/lib/aspace_oauth.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module AspaceOauth
+  def self.build_url(host, path, params = {})
+    URI::HTTPS.build(
+      host: URI(host).host,
+      path: path,
+      query: URI.encode_www_form(params)
+    ).to_s
+  end
+
+  def self.cas_logout_url
+    config = get_oauth_config_for('cas')
+    return unless config
+
+    host   = config[:config][:url]
+    path   = config[:config][:logout_url]
+    params = { service: AppConfig[:frontend_proxy_url] }
+    build_url(host, path, params)
+  end
+
+  def self.get_email(auth)
+    email = nil
+    if auth[:info].key?(:email) && !auth[:info][:email].nil?
+      email = auth[:info][:email]
+    elsif auth[:extra].key?(:email) && !auth[:extra][:email].nil?
+      email = auth[:extra][:email]
+    elsif auth[:extra].key?(:response_object)
+      if auth[:extra][:response_object].name_id
+        email = auth[:extra][:response_object].name_id
+      end
+    end
+    email
+  end
+
+  def self.get_oauth_config_for(strategy)
+    AppConfig[:oauth_definitions].find { |oauth| oauth[:provider] == strategy }
+  end
+
+  def self.saml_logout_url
+    config = get_oauth_config_for('saml')
+    return unless config
+
+    build_url(
+      AppConfig[:frontend_proxy_url],
+      "#{AppConfig[:frontend_proxy_prefix]}auth/saml/spslo"
+    )
+  end
+
+  def self.use_uid?
+    AppConfig.has_key?(:oauth_idtype) && AppConfig[:oauth_idtype] == :uid
+  end
+end

--- a/plugins/aspace-oauth/frontend/lib/nycid.rb
+++ b/plugins/aspace-oauth/frontend/lib/nycid.rb
@@ -1,0 +1,125 @@
+module NYCID
+  class NYCIDWebServices
+    # Validate a user's email address
+    EMAIL_VALIDATION_ENDPOINT = '/account/validateEmail.htm'.freeze
+    # Check the validation status of the user's email address
+    EMAIL_VALIDATION_STATUS_ENDPOINT = '/account/api/isEmailValidated.htm'.freeze
+    # Search for a user by their guid or email addresss
+    USER_SEARCH_ENDPOINT = '/account/api/user.htm'.freeze
+    # Search for multiple users by their guids or their "Start Date"
+    USERS_SEARCH_ENDPOINT = '/account/api/getUsers.htm'.freeze
+    # Default HTTP Verb for API
+    DEFAULT_METHOD = 'GET'.freeze
+
+    def initialize(
+        service_account_username: AppConfig[:nyc_id_web_services_username],
+        service_account_password: AppConfig[:nyc_id_web_services_password],
+        api_uri: AppConfig[:nyc_id_web_services_url]
+    )
+      @service_account_username = service_account_username
+      @service_account_password = service_account_password
+      @api_uri = api_uri
+      @acs_url = AppConfig[:saml_acs]
+    end
+
+    # Checks the users email validation status using NYC.ID Web Services.
+    #
+    # Params:
+    # * +:guid+ - Unique identifier for the user from NYC.ID
+    #
+    # Returns:
+    # Boolean value of user's email validation status.
+    def check_email_validation_status(guid)
+      params = { guid: guid }
+      response = nycid_web_services_request(
+          EMAIL_VALIDATION_STATUS_ENDPOINT,
+          params,
+          method: DEFAULT_METHOD
+      )
+      response['validated']
+    end
+
+    # Validates the users email address using NYC.ID Web Services.
+    #
+    # Params:
+    # * +:email_address+ - User's email address.
+    #
+    # Returns:
+    # String of URL to request another validation email.
+    def validate_email(email_address)
+      if email_address.nil?
+        raise ArgumentError, 'You must provide an email_address'
+      end
+
+      "#{@api_uri}#{EMAIL_VALIDATION_ENDPOINT}?emailAddress=#{email_address}&target=#{@acs_url}"
+    end
+
+    # Retrieves a JSON-formatted user from the NYC.ID Web Services API.
+    #
+    # Params:
+    # * +:guid+ - User's unique identifier.
+    #
+    # Returns:
+    # JSON-formatted user as specified by NYC.ID (http://nyc4d.nycnet/nycid/search.shtml#json-formatted-users).
+    def search_user(guid)
+      nycid_web_services_request(
+          USER_SEARCH_ENDPOINT,
+          { guid: guid },
+          method: DEFAULT_METHOD
+      )
+    end
+
+    private
+
+    # Query the NYC.ID Web Services API.
+    #
+    # Params:
+    # * +:endpoint+ - Services endpoint being targeted.
+    # * +:params+ - Query parameters for the endpoint.
+    # * +:method+ - HTTP Verb being used in the API call. Defaults to "GET".
+    #
+    # Returns:
+    # HTTP Response from NYC.ID Web Services API Endpoint.
+    def nycid_web_services_request(endpoint, params, method: DEFAULT_METHOD)
+      Rails.logger.info "NYC Web Services Request: #{method} #{endpoint}"
+      Rails.logger.info "#{params}"
+      params[:userName] = @service_account_username
+      signature = generate_nycid_signature(endpoint, params, @service_account_password, method: method)
+      params[:signature] = signature
+
+      url = @api_uri + "#{endpoint}"
+      Rails.logger.info "#{url}"
+      response = HTTParty.get(url, query: params)
+      if response.code != 200
+        Rails.logger.error JSON.pretty_generate(response.parsed_response)
+      end
+
+      response.parsed_response
+    end
+
+    # Generate a signature for a request to the NYC.ID Web Services API.
+    #
+    # Params:
+    # * +:url_path+ - URL Path being accessed (without domain). See constants for valid values.
+    # * +:query_string+ - Query String in a hash of (key, value) pairs.
+    # * +:nycid_web_services_password+ - Password used to authenticate with NYC.ID Web Services.
+    # * +:method+ - HTTP Verb being used in the API call. Defaults to "GET".
+    #
+    # Returns:
+    # HMAC-SHA256 Signature for NYC.ID Web Services request.
+    def generate_nycid_signature(url_path, query_string, signing_key, method: DEFAULT_METHOD)
+      # endpoint must begin with a forward slash
+      url_path = "/#{url_path}" if url_path.first != '/'
+
+      # Sort the query string by keys
+      parameter_values = Hash[query_string.sort_by { |key, val| key.to_s }]
+
+      # Signature contains only the values of the sorted query string joined with no separator
+      signature_parameter_values = parameter_values.map { |key, val| "#{val}" }.join
+
+      value_to_sign = "#{method}#{url_path}#{signature_parameter_values}"
+
+      OpenSSL::HMAC.hexdigest('sha256', signing_key, value_to_sign)
+    end
+  end
+end

--- a/plugins/aspace-oauth/frontend/plugin_init.rb
+++ b/plugins/aspace-oauth/frontend/plugin_init.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative 'lib/aspace_oauth'
+oauth_definitions = AppConfig[:authentication_sources].find_all do |as|
+  as[:model] == 'ASOauth'
+end
+unless oauth_definitions.any?
+  raise 'OmniAuth plugin enabled but no definitions provided =('
+end
+
+# also used for ui [refactor]
+AppConfig[:oauth_definitions] = oauth_definitions
+ArchivesSpace::Application.extend_aspace_routes(
+  File.join(File.dirname(__FILE__), 'routes.rb')
+)
+require 'omniauth'
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  oauth_definitions.each do |oauth_definition|
+    verify_ssl = oauth_definition.fetch(:verify_ssl, true)
+    config = oauth_definition[:config]
+    if oauth_definition.key? :metadata_parser_url
+      idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+      idp_metadata        = idp_metadata_parser.parse_remote_to_hash(
+        oauth_definition[:metadata_parser_url], verify_ssl
+      )
+      config = idp_metadata.merge(config)
+    end
+    if config.key? :security
+      # replace strings with constants for *_method
+      [:digest_method, :signature_method].each do |m|
+        if config[:security].key? m
+          config[:security][m] = config[:security][m].constantize
+        end
+      end
+    end
+    provider oauth_definition[:provider], config
+    $stdout.puts "REGISTERED OAUTH PROVIDER WITH CONFIG: #{config}"
+  end
+end

--- a/plugins/aspace-oauth/frontend/routes.rb
+++ b/plugins/aspace-oauth/frontend/routes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+ArchivesSpace::Application.routes.draw do
+  scope AppConfig[:frontend_proxy_prefix] do
+    # OMNIAUTH GENERATED ROUTES:
+    # OMNIAUTH:      /auth/:provider
+    # OMNIAUTH-SAML: /auth/saml/metadata
+    # OMNIAUTH-SAML: /auth/saml/slo
+    # OMNIAUTH-SAML: /auth/saml/spslo
+
+    get  '/auth/:provider/callback', to: 'oauth#create'
+    post '/auth/:provider/callback', to: 'oauth#create'
+    get  '/auth/failure',            to: 'oauth#failure'
+    get  '/auth/cas_logout',         to: 'oauth#cas_logout'
+    get  '/auth/saml_logout',        to: 'oauth#saml_logout'
+  end
+end

--- a/plugins/aspace-oauth/frontend/views/shared/_header_global.html.erb
+++ b/plugins/aspace-oauth/frontend/views/shared/_header_global.html.erb
@@ -1,0 +1,47 @@
+<div class="container global-header">
+  <nav class="navbar">
+    <div class="container">
+
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target=".nav-global-collapse">
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+      </div>
+
+      <% if !session[:user] %>
+        <button type="button" class="btn btn-default pull-right btn-collapse-login navbar-btn" data-toggle="collapse" data-target=".nav-global-collapse">
+          <%= I18n.t("navbar.login") %>
+        </button>
+      <% end %>
+      <div class="navbar-collapse nav-global-collapse collapse navbar-right navbar-default">
+        <ul class="nav pull-right navbar-nav navbar-login">
+          <%= render "shared/header_user" %>
+          <!-- PLUGIN BEGIN -->
+          <% if AppConfig[:oauth_definitions] and !session[:user] %>
+            <% AppConfig[:oauth_definitions].each do |oauth_definition| %>
+              <li><%= link_to oauth_definition[:label], "#{AppConfig[:frontend_proxy_prefix]}auth/#{oauth_definition[:provider]}" %></li>
+            <% end %>
+          <% end %>
+          <!-- PLUGIN END -->
+          <% if ArchivesSpaceHelp.enabled? %>
+            <li><%= link_to_help :link_opts => {"data-placement" => (session[:user] ? "left" : "bottom")} %></li>
+          <% end %>
+        </ul>
+      </div><!-- nav-collapse -->
+    </div>
+  </nav>
+</div>
+<!-- PLUGIN BEGIN -->
+<% if session[:user] %>
+  <% AppConfig[:oauth_definitions].find_all{ |od| od[:slo_link] }.each do |oauth_definition| %>
+    <script type="text/javascript">
+      (function() {
+        var logout = $('a[href~="/logout"]').parent().parent();
+        logout.append('<li><%= link_to("#{oauth_definition[:provider].upcase} Logout", "#{AppConfig[:frontend_proxy_prefix]}auth/#{oauth_definition[:provider]}_logout") %></li>');
+      })();
+    </script>
+  <% end %>
+<% end %>
+<!-- PLUGIN END -->

--- a/plugins/aspace-oauth/frontend/views/welcome/index.html.erb
+++ b/plugins/aspace-oauth/frontend/views/welcome/index.html.erb
@@ -1,0 +1,15 @@
+<%= setup_context :title => "Home", :suppress_breadcrumb => true %>
+
+<div class="row">
+  <div class="col-md-12">
+    <%= render_aspace_partial :partial => "shared/flash_messages" %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-0 col-lg-4 lg-min-w-450px p30px">
+    <h2><%= I18n.t "welcome.heading" %></h2>
+    <%= welcome_message %>
+  </div>
+
+</div>


### PR DESCRIPTION
This PR sets up login with NYC.ID through the aspace-oauth plugin.

Steps to setup:
1. `build/run db:migrate` to upgrade to the latest migration (adds guid to users table)
2. Create cert/key used for NYC.ID using `openssl req -new -x509 -days 3652 -nodes -out saml.crt -keyout saml.key` 
3. Edit config values in `archivesspace/common/config/config.rb`
4. Add `aspace-oauth` to `AppConfig[:plugins]`

Example `config.rb` setup:
```
# NYC.ID config values
AppConfig[:idp_metadata_url] = "https://fidm.us1.gigya.com/saml/v2.0/3_DkZigi2v_eW7z-cZt8PAw-cYWQYg2d8VqABUFRZUhhzxNAdwR5brLl_h8Hqbo7Bm/idp/metadata"
AppConfig[:saml_acs] = "https://jon-dev.getinfo.nyc/auth/saml/callback"
AppConfig[:saml_issuer] = "https://jon-dev.getinfo.nyc/auth/saml/metadata"
AppConfig[:saml_certificate_path] = "/Users/jyu/archivesspace/common/config/saml.crt"
AppConfig[:saml_certificate_key_path] = "/Users/jyu/archivesspace/common/config/saml.key"
AppConfig[:saml_certificate] = File.read(AppConfig[:saml_certificate_path])
AppConfig[:saml_certificate_key] = File.read(AppConfig[:saml_certificate_key_path])
AppConfig[:nyc_id_web_services_username] = ""
AppConfig[:nyc_id_web_services_password] = ""
AppConfig[:nyc_id_web_services_url] = "https://accounts-nonprd.nyc.gov/"
AppConfig[:approved_domains] = ['records.nyc.gov']
AppConfig[:authentication_sources] = [
    {
        model: 'ASOauth',
        provider: 'saml',
        label: 'Log In',
        slo_link: false,
        metadata_parser_url: AppConfig[:idp_metadata_url],
        config: {
            :assertion_consumer_service_url     => AppConfig[:saml_acs],
            :issuer                             => AppConfig[:saml_issuer],
            :name_identifier_format             => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
            :certificate                        => AppConfig[:saml_certificate],
            :private_key                        => AppConfig[:saml_certificate_key],
            :security                           => {
                authn_requests_signed:     true,
                want_assertions_signed:    true,
                want_assertions_encrypted: false,
                metadata_signed:           true,
                digest_method:             "XMLSecurity::Document::SHA256",
                signature_method:          "XMLSecurity::Document::RSA_SHA256",
                embed_sign:                false,
            },
            :attribute_statements => {
                email: ["urn:oid:0.9.2342.19200300.100.1.3"],
            },
        }
    }
]
```

`AppConfig[:idp_metadata_url]` is the url to the IDP metadata provider. For the non-prod environment we will use `https://fidm.us1.gigya.com/saml/v2.0/3_DkZigi2v_eW7z-cZt8PAw-cYWQYg2d8VqABUFRZUhhzxNAdwR5brLl_h8Hqbo7Bm/idp/metadata`

`AppConfig[:saml_acs]` format will be `https://<YOUR_SITE_URL>/auth/saml/callback`

`AppConfig[:saml_issuer]` format will be `https://<YOUR_SITE_URL>/auth/saml/metadata`

`AppConfig[:saml_certificate_path]` is the absolute path to your saml certificate.

`AppConfig[:saml_certificate_key_path]` = is the absolute path to your saml certificate key.

`AppConfig[:saml_certificate]` is the contents of `saml.crt` that was read from `AppConfig[:saml_certificate_path]`.

`AppConfig[:saml_certificate_key]` is the contents of `saml.key` that was `AppConfig[:saml_certificate_key_path]`.

`AppConfig[:nyc_id_web_services_username]` is the username of the service account created to use NYC.ID Webservices.

`AppConfig[:nyc_id_web_services_password]` is the password of the service account created to use NYC.ID Webservices

`AppConfig[:nyc_id_web_services_url]` is the URL used for NYC.ID Webservices. For the non-prod environment we will use `https://accounts-nonprd.nyc.gov/`

`AppConfig[:approved_domains]` is the list of all approved domains that can login to the staff user interface through NYC.ID. By default we will use `['records.nyc.gov']`