### PR TITLE
AB#640 - Contact from textual changes

### DIFF
--- a/common/config/config.rb
+++ b/common/config/config.rb
@@ -12,6 +12,7 @@ AppConfig[:plugins] = ['local',  'lcnaf', 'aspace-doris-public']
 AppConfig[:pui_hide][:repositories] = true
 AppConfig[:pui_hide][:digital_objects] = true
 AppConfig[:pui_hide][:accessions] = true
+AppConfig[:pui_hide][:contact] = false
 
 # Enable / disable PUI resource/archival object page actions
 AppConfig[:pui_page_actions_cite] = false

--- a/common/config/config.rb
+++ b/common/config/config.rb
@@ -12,7 +12,6 @@ AppConfig[:plugins] = ['local',  'lcnaf', 'aspace-doris-public']
 AppConfig[:pui_hide][:repositories] = true
 AppConfig[:pui_hide][:digital_objects] = true
 AppConfig[:pui_hide][:accessions] = true
-AppConfig[:pui_hide][:contact] = false
 
 # Enable / disable PUI resource/archival object page actions
 AppConfig[:pui_page_actions_cite] = false

--- a/public/config/initializers/public_new_defaults.rb
+++ b/public/config/initializers/public_new_defaults.rb
@@ -24,8 +24,6 @@ module PublicNewDefaults
           $MAIN_MENU.push(['/agents', 'pui_agent._plural'])
         when :classifications
           $MAIN_MENU.push(['/classifications', 'classification._plural'])
-        when :contact
-          $MAIN_MENU.push(['/contact', 'contact_form'])
       end
     end
   end

--- a/public/config/initializers/public_new_defaults.rb
+++ b/public/config/initializers/public_new_defaults.rb
@@ -24,6 +24,8 @@ module PublicNewDefaults
           $MAIN_MENU.push(['/agents', 'pui_agent._plural'])
         when :classifications
           $MAIN_MENU.push(['/classifications', 'classification._plural'])
+        when :contact
+          $MAIN_MENU.push(['/contact', 'contact_form'])
       end
     end
   end


### PR DESCRIPTION
- Updated homepage button from "Email us" to "Contact Us" and updated link
- Updated homepage text from "contact us at research@records.nyc.gov" to "use our <link>contact form</link> to start your research.
- Updated footer text to "Contact us to start your research"  and updated link
- Added 'Contact Us' to header navigation