### PR TITLE
SSA AppScan Fixes

### DIFF
--- a/backend/config.ru
+++ b/backend/config.ru
@@ -7,6 +7,9 @@ def app
   ArchivesSpaceService
 end
 
+require 'rack/protection'
+
 map "/" do
+  use Rack::Protection, :except => [:remote_token, :session_hijacking], :permitted_origins => [AppConfig[:frontend_proxy_url], AppConfig[:frontend_url], AppConfig[:public_proxy_url], AppConfig[:public_url], AppConfig[:nyc_id_web_services_url]]
   run ArchivesSpaceService
 end

--- a/backend/config.ru
+++ b/backend/config.ru
@@ -10,6 +10,6 @@ end
 require 'rack/protection'
 
 map "/" do
-  use Rack::Protection
+  use Rack::Protection, :except => :remote_token
   run ArchivesSpaceService
 end

--- a/backend/config.ru
+++ b/backend/config.ru
@@ -7,9 +7,6 @@ def app
   ArchivesSpaceService
 end
 
-require 'rack/protection'
-
 map "/" do
-  use Rack::Protection, :except => [:remote_token, :session_hijacking], :permitted_origins => [AppConfig[:frontend_proxy_url], AppConfig[:frontend_url], AppConfig[:public_proxy_url], AppConfig[:public_url], AppConfig[:nyc_id_web_services_url]]
   run ArchivesSpaceService
 end

--- a/backend/config.ru
+++ b/backend/config.ru
@@ -7,9 +7,6 @@ def app
   ArchivesSpaceService
 end
 
-require 'rack/protection'
-
 map "/" do
-  use Rack::Protection, :except => [:remote_token, :session_hijacking], :permitted_origins => [AppConfig[:frontend_proxy_url], AppConfig[:frontend_url], AppConfig[:public_proxy_url], AppConfig[:public_url], 'https://accounts-nonprd.nyc.gov']
   run ArchivesSpaceService
 end

--- a/backend/config.ru
+++ b/backend/config.ru
@@ -7,6 +7,9 @@ def app
   ArchivesSpaceService
 end
 
+require 'rack/protection'
+
 map "/" do
+  use Rack::Protection
   run ArchivesSpaceService
 end

--- a/backend/config.ru
+++ b/backend/config.ru
@@ -10,6 +10,6 @@ end
 require 'rack/protection'
 
 map "/" do
-  use Rack::Protection, :except => [:remote_token, :session_hijacking]
+  use Rack::Protection, :except => [:remote_token, :session_hijacking], :permitted_origins => [AppConfig[:frontend_proxy_url], AppConfig[:frontend_url], AppConfig[:public_proxy_url], AppConfig[:public_url], 'https://accounts-nonprd.nyc.gov']
   run ArchivesSpaceService
 end

--- a/backend/config.ru
+++ b/backend/config.ru
@@ -10,6 +10,6 @@ end
 require 'rack/protection'
 
 map "/" do
-  use Rack::Protection, :except => :remote_token
+  use Rack::Protection, :except => [:remote_token, :session_hijacking]
   run ArchivesSpaceService
 end

--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -338,7 +338,11 @@ class ApplicationController < ActionController::Base
   end
 
   def set_user_repository_cookie(repository_uri)
-    cookies[user_repository_cookie_key] = repository_uri
+    cookies[user_repository_cookie_key] = {
+        :value => repository_uri,
+        :secure => true,
+        :httponly => true
+    }
   end
 
 

--- a/frontend/app/models/user.rb
+++ b/frontend/app/models/user.rb
@@ -24,7 +24,11 @@ class User < JSONModel(:user)
 
 
   def self.store_permissions(permissions, context)
-    context.send(:cookies).signed[:archivesspace_permissions] = 'ZLIB:' + Zlib::Deflate.deflate(ASUtils.to_json(Permissions.pack(permissions)))
+    context.send(:cookies).signed[:archivesspace_permissions] = {
+        :value => 'ZLIB:' + Zlib::Deflate.deflate(ASUtils.to_json(Permissions.pack(permissions))),
+        :secure => true,
+        :httponly => true
+    }
     context.session[:last_permission_refresh] = Time.now.to_i
   end
 

--- a/frontend/app/views/accessions/_form.html.erb
+++ b/frontend/app/views/accessions/_form.html.erb
@@ -56,5 +56,5 @@
 
 <div class="form-actions">
   <button type="submit" class="btn btn-primary"><%= I18n.t("accession._frontend.action.save") %></button>
-  <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+  <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
 </div>

--- a/frontend/app/views/agents/defaults.html.erb
+++ b/frontend/app/views/agents/defaults.html.erb
@@ -17,7 +17,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("#{@agent.agent_type}._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/agents/edit.html.erb
+++ b/frontend/app/views/agents/edit.html.erb
@@ -14,7 +14,7 @@
           <%= render_aspace_partial :partial => "agents/form", :locals => {:form => form} %>
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("#{@agent.agent_type}._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/agents/new.html.erb
+++ b/frontend/app/views/agents/new.html.erb
@@ -17,7 +17,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("#{@agent.agent_type}._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/agents/required.html.erb
+++ b/frontend/app/views/agents/required.html.erb
@@ -17,7 +17,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("#{@agent.agent_type}._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/archival_objects/_edit_inline.html.erb
+++ b/frontend/app/views/archival_objects/_edit_inline.html.erb
@@ -10,7 +10,7 @@
           <%= render_aspace_partial :partial => "archival_objects/form_container", :locals => {:form => form} %>
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("archival_object._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/archival_objects/_new_inline.html.erb
+++ b/frontend/app/views/archival_objects/_new_inline.html.erb
@@ -13,7 +13,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("archival_object._frontend.action.save") %></button>
               <button type="button" id="createPlusOne" class="btn btn-primary btn-plus-one createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/archival_objects/defaults.html.erb
+++ b/frontend/app/views/archival_objects/defaults.html.erb
@@ -15,7 +15,7 @@
 
              <div class="form-actions">
                 <button type="submit" class="btn btn-primary"><%= I18n.t("actions.save_prefix") %> <%= I18n.t("resource._singular") %></button>
-                <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+                <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
              </div>
            </div>
          </div>

--- a/frontend/app/views/assessment_attributes/edit.html.erb
+++ b/frontend/app/views/assessment_attributes/edit.html.erb
@@ -215,7 +215,7 @@
 
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("assessment_attribute_definitions._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/assessments/edit.html.erb
+++ b/frontend/app/views/assessments/edit.html.erb
@@ -17,7 +17,7 @@
 
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("assessment._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
 
         </div>

--- a/frontend/app/views/assessments/new.html.erb
+++ b/frontend/app/views/assessments/new.html.erb
@@ -16,7 +16,7 @@
 
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("assessment._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/classification_terms/_edit_inline.html.erb
+++ b/frontend/app/views/classification_terms/_edit_inline.html.erb
@@ -10,7 +10,7 @@
           <%= render_aspace_partial :partial => "classification_terms/form_container", :locals => {:form => form} %>
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("classification_term._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/classification_terms/_new_inline.html.erb
+++ b/frontend/app/views/classification_terms/_new_inline.html.erb
@@ -13,7 +13,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("classification_term._frontend.action.save") %></button>
               <button type="button" id="createPlusOne" class="btn btn-primary btn-plus-one createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/classification_terms/defaults.html.erb
+++ b/frontend/app/views/classification_terms/defaults.html.erb
@@ -14,7 +14,7 @@
 
            <div class="form-actions">
               <button type="submit" class="btn btn-primary"><%= I18n.t("actions.save_prefix") %> <%= I18n.t("classification_term._singular") %></button>
-              <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+              <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
            </div>
          </div>
        </div>

--- a/frontend/app/views/classifications/_edit_inline.html.erb
+++ b/frontend/app/views/classifications/_edit_inline.html.erb
@@ -10,7 +10,7 @@
            <%= render_aspace_partial :partial => "classifications/form_container", :locals => {:form => form} %>
            <div class="form-actions">
              <button type="submit" class="btn btn-primary"><%= I18n.t("classification._frontend.action.save") %></button>
-              <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+              <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
            </div>
          </div>
       </div>

--- a/frontend/app/views/classifications/_new_inline.html.erb
+++ b/frontend/app/views/classifications/_new_inline.html.erb
@@ -9,7 +9,7 @@
           <%= render_aspace_partial :partial => "classifications/form_container", :locals => {:form => form} %>
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("classification._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/classifications/defaults.html.erb
+++ b/frontend/app/views/classifications/defaults.html.erb
@@ -14,7 +14,7 @@
 
            <div class="form-actions">
               <button type="submit" class="btn btn-primary"><%= I18n.t("actions.save_prefix") %> <%= I18n.t("classification._singular") %></button>
-              <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+              <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
            </div>
          </div>
        </div>

--- a/frontend/app/views/classifications/new.html.erb
+++ b/frontend/app/views/classifications/new.html.erb
@@ -14,7 +14,7 @@
 
            <div class="form-actions">
               <button type="submit" class="btn btn-primary"><%= I18n.t("actions.save_prefix") %> <%= I18n.t("classification._singular") %></button>
-              <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+              <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
            </div>
          </div>
        </div>

--- a/frontend/app/views/container_profiles/edit.html.erb
+++ b/frontend/app/views/container_profiles/edit.html.erb
@@ -15,7 +15,7 @@
           <%= render_aspace_partial :partial => "container_profiles/form", :locals => {:form => form} %>
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("container_profile._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/container_profiles/new.html.erb
+++ b/frontend/app/views/container_profiles/new.html.erb
@@ -20,7 +20,7 @@
               btn-primary"><%= I18n.t("container_profile._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/digital_object_components/_edit_inline.html.erb
+++ b/frontend/app/views/digital_object_components/_edit_inline.html.erb
@@ -10,7 +10,7 @@
           <%= render_aspace_partial :partial => "digital_object_components/form_container", :locals => {:form => form} %>
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("digital_object_component._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/digital_object_components/_new_inline.html.erb
+++ b/frontend/app/views/digital_object_components/_new_inline.html.erb
@@ -13,7 +13,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("digital_object_component._frontend.action.save") %></button>
               <button type="button" id="createPlusOne" class="btn btn-primary btn-plus-one createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/digital_object_components/defaults.html.erb
+++ b/frontend/app/views/digital_object_components/defaults.html.erb
@@ -14,7 +14,7 @@
 
              <div class="form-actions">
                <button type="submit" class="btn btn-primary"><%= I18n.t("digital_object_component._frontend.action.save") %></button>
-                <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+                <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
              </div>
            </div>
          </div>

--- a/frontend/app/views/digital_objects/_edit_inline.html.erb
+++ b/frontend/app/views/digital_objects/_edit_inline.html.erb
@@ -19,7 +19,7 @@
           <%= render_aspace_partial :partial => "digital_objects/form_container", :locals => {:form => form} %>
            <div class="form-actions">
              <button type="submit" class="btn btn-primary"><%= I18n.t("digital_object._frontend.action.save") %></button>
-              <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+              <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
            </div>
          </div>
       </div>

--- a/frontend/app/views/digital_objects/defaults.html.erb
+++ b/frontend/app/views/digital_objects/defaults.html.erb
@@ -20,7 +20,7 @@
 
              <div class="form-actions">
                <button type="submit" class="btn btn-primary"><%= I18n.t("digital_object._frontend.action.save") %></button>
-                <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+                <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
              </div>
            </div>
          </div>

--- a/frontend/app/views/digital_objects/new.html.erb
+++ b/frontend/app/views/digital_objects/new.html.erb
@@ -20,7 +20,7 @@
 
              <div class="form-actions">
                <button type="submit" class="btn btn-primary"><%= I18n.t("digital_object._frontend.action.save") %></button>
-                <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+                <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
              </div>
            </div>
          </div>

--- a/frontend/app/views/events/defaults.html.erb
+++ b/frontend/app/views/events/defaults.html.erb
@@ -24,7 +24,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("event._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/events/edit.html.erb
+++ b/frontend/app/views/events/edit.html.erb
@@ -19,7 +19,7 @@
           <%= render_aspace_partial :partial => "events/form", :locals => {:form => form} %>
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("event._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/events/new.html.erb
+++ b/frontend/app/views/events/new.html.erb
@@ -24,7 +24,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("event._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/jobs/new.html.erb
+++ b/frontend/app/views/jobs/new.html.erb
@@ -21,7 +21,7 @@
             <div class="btn-group">
               <button type="submit" class="btn btn-primary"><%= I18n.t("job._frontend.actions.save") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/location_profiles/edit.html.erb
+++ b/frontend/app/views/location_profiles/edit.html.erb
@@ -15,7 +15,7 @@
           <%= render_aspace_partial :partial => "location_profiles/form", :locals => {:form => form} %>
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("location_profile._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/location_profiles/new.html.erb
+++ b/frontend/app/views/location_profiles/new.html.erb
@@ -20,7 +20,7 @@
               btn-primary"><%= I18n.t("location_profile._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/locations/batch.html.erb
+++ b/frontend/app/views/locations/batch.html.erb
@@ -49,7 +49,7 @@
             <% if !@is_batch_update %> 
               <button type="button" class="btn preview-locations"><%= I18n.t("location_batch._frontend.action.preview") %></button>
             <% end %>   
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/locations/defaults.html.erb
+++ b/frontend/app/views/locations/defaults.html.erb
@@ -19,7 +19,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("actions.save_prefix") %> <%= I18n.t("location._singular") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/locations/edit.html.erb
+++ b/frontend/app/views/locations/edit.html.erb
@@ -15,7 +15,7 @@
           <%= render_aspace_partial :partial => "locations/form", :locals => {:form => form} %>
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("location._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/locations/new.html.erb
+++ b/frontend/app/views/locations/new.html.erb
@@ -19,7 +19,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("actions.save_prefix") %> <%= I18n.t("location._singular") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/repositories/edit.html.erb
+++ b/frontend/app/views/repositories/edit.html.erb
@@ -17,7 +17,7 @@
 
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("repository._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/repositories/new.html.erb
+++ b/frontend/app/views/repositories/new.html.erb
@@ -18,7 +18,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("repository._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/resources/_edit_inline.html.erb
+++ b/frontend/app/views/resources/_edit_inline.html.erb
@@ -10,7 +10,7 @@
            <%= render_aspace_partial :partial => "resources/form_container", :locals => {:form => form} %>
            <div class="form-actions">
              <button type="submit" class="btn btn-primary"><%= I18n.t("resource._frontend.action.save") %></button>
-              <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+              <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
            </div>
          </div>
       </div>

--- a/frontend/app/views/resources/_new_inline.html.erb
+++ b/frontend/app/views/resources/_new_inline.html.erb
@@ -9,7 +9,7 @@
           <%= render_aspace_partial :partial => "resources/form_container", :locals => {:form => form} %>
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("resource._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/resources/defaults.html.erb
+++ b/frontend/app/views/resources/defaults.html.erb
@@ -15,7 +15,7 @@
 
              <div class="form-actions">
                 <button type="submit" class="btn btn-primary"><%= I18n.t("actions.save_prefix") %> <%= I18n.t("resource._singular") %></button>
-                <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+                <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
              </div>
            </div>
          </div>

--- a/frontend/app/views/resources/new.html.erb
+++ b/frontend/app/views/resources/new.html.erb
@@ -15,7 +15,7 @@
 
              <div class="form-actions">
                 <button type="submit" class="btn btn-primary"><%= I18n.t("actions.save_prefix") %> <%= I18n.t("resource._singular") %></button>
-                <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+                <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
              </div>
            </div>
          </div>

--- a/frontend/app/views/subjects/defaults.html.erb
+++ b/frontend/app/views/subjects/defaults.html.erb
@@ -18,7 +18,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("subject._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/subjects/edit.html.erb
+++ b/frontend/app/views/subjects/edit.html.erb
@@ -15,7 +15,7 @@
           <%= render_aspace_partial :partial => "subjects/form", :locals => {:form => form} %>
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("subject._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/subjects/new.html.erb
+++ b/frontend/app/views/subjects/new.html.erb
@@ -18,7 +18,7 @@
               <button type="submit" class="btn btn-primary"><%= I18n.t("subject._frontend.action.save") %></button>
               <button type="submit" id="createPlusOne" name="plus_one" class="btn btn-primary createPlusOneBtn"><%= I18n.t("actions.save_plus_one") %></button>
             </div>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
         </div>
       </div>

--- a/frontend/app/views/top_containers/edit.html.erb
+++ b/frontend/app/views/top_containers/edit.html.erb
@@ -16,7 +16,7 @@
 
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("top_container._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
 
         </div>

--- a/frontend/app/views/top_containers/new.html.erb
+++ b/frontend/app/views/top_containers/new.html.erb
@@ -16,7 +16,7 @@
 
           <div class="form-actions">
             <button type="submit" class="btn btn-primary"><%= I18n.t("top_container._frontend.action.save") %></button>
-            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+            <%= sanitize link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
           </div>
 
         </div>

--- a/frontend/config/application.rb
+++ b/frontend/config/application.rb
@@ -132,6 +132,8 @@ module ArchivesSpace
       end
     end
 
+    config.force_ssl = true
+
     # ArchivesSpace Configuration
     AppConfig.load_into(config)
   end

--- a/frontend/config/application.rb
+++ b/frontend/config/application.rb
@@ -132,8 +132,6 @@ module ArchivesSpace
       end
     end
 
-    config.force_ssl = true
-
     # ArchivesSpace Configuration
     AppConfig.load_into(config)
   end

--- a/frontend/config/initializers/session_store.rb
+++ b/frontend/config/initializers/session_store.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Use httponly because some of our AJAX handlers need access to the session too.
-ArchivesSpace::Application.config.session_store :cookie_store, key: "#{AppConfig[:cookie_prefix]}_session"
+ArchivesSpace::Application.config.session_store :cookie_store, key: "#{AppConfig[:cookie_prefix]}_session", secure: true
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/public/config/application.rb
+++ b/public/config/application.rb
@@ -97,8 +97,6 @@ module ArchivesSpacePublic
       config.action_mailer.perform_deliveries = false
     end
 
-    config.force_ssl = true
-
   end
 end
 

--- a/public/config/application.rb
+++ b/public/config/application.rb
@@ -97,6 +97,8 @@ module ArchivesSpacePublic
       config.action_mailer.perform_deliveries = false
     end
 
+    config.force_ssl = true
+
   end
 end
 

--- a/public/config/initializers/session_store.rb
+++ b/public/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_archivesspace-public_session'
+Rails.application.config.session_store :cookie_store, key: '_archivesspace-public_session', secure: true


### PR DESCRIPTION
This PR adds the following fixes for issues found during the internal AppScan:
- XSS vulnerabilities found in the cancel button on the staff side. Fixed by adding `sanitize` to `link_to` statments.
- Added `secure` and `http_only` attributes to cookies.